### PR TITLE
Update example to show correct way to call Auth0Lock

### DIFF
--- a/examples/redirect-lock-with-api/app.jsx
+++ b/examples/redirect-lock-with-api/app.jsx
@@ -5,7 +5,7 @@ var App = React.createClass({
     this.setState({idToken: this.getIdToken()})
   },
   createLock: function() {
-    this.lock = new Auth0Lock(this.props.clientId, this.props.domain);
+    this.lock = new Auth0Lock({clientID: this.props.clientId, domain: this.props.domain});
   },
   setupAjax: function() {
     $.ajaxSetup({


### PR DESCRIPTION
The old example threw an error:

```
Uncaught Error: clientID is required.
```

This is because the Auth0Lock prototype requires an options object, not individual args. I'm assuming the Auth0Lock client was updated and the React example was not.