### PR TITLE
It's awkward to make people cast user as something more specific

### DIFF
--- a/src/auth-state.tsx
+++ b/src/auth-state.tsx
@@ -1,8 +1,10 @@
+export type User = any; // eslint-disable-line @typescript-eslint/no-explicit-any
+
 export interface AuthState {
   error?: Error;
   isAuthenticated: boolean;
   isLoading: boolean;
-  user?: unknown;
+  user?: User;
 }
 
 export const initialAuthState: AuthState = {

--- a/src/reducer.tsx
+++ b/src/reducer.tsx
@@ -1,11 +1,11 @@
-import { AuthState } from './auth-state';
+import { AuthState, User } from './auth-state';
 
 type Action =
   | { type: 'LOGIN_POPUP_STARTED' }
   | {
       type: 'INITIALISED' | 'LOGIN_POPUP_COMPLETE';
       isAuthenticated: boolean;
-      user?: unknown;
+      user?: User;
     }
   | { type: 'ERROR'; error: Error };
 

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -3,7 +3,7 @@ const ERROR_RE = /[?&]error=[^&]+/;
 
 export type AppState = {
   returnTo?: string;
-  [key: string]: unknown;
+  [key: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 };
 
 export const hasAuthParams = (searchParams = window.location.search): boolean =>


### PR DESCRIPTION
### Description

Allow `any` as type for user

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
