### PR TITLE
Add the onRedirecting option to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,12 @@ Protect a route component using the `withLoginRequired` higher order component. 
 import React from 'react';
 import { withLoginRequired } from '@auth0/auth0-react';
 
+// Show a message while the user waits to be redirected to the login page.
+const Redirecting = () => <div>Redirecting you to the login page...</div>;
+
 const PrivateRoute = () => <div>Private</div>;
 
-export default withLoginRequired(PrivateRoute);
+export default withLoginRequired(PrivateRoute, Redirecting);
 ```
 
 ### Access an API


### PR DESCRIPTION
### Description

Add some information about showing a message while the user is being redirected to the login page from a protected route.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
