### PR TITLE
getToken methods were being called in the wrong scope

### DIFF
--- a/__tests__/auth-provider.test.tsx
+++ b/__tests__/auth-provider.test.tsx
@@ -256,6 +256,18 @@ describe('Auth0Provider', () => {
     );
   });
 
+  it('should call getAccessTokenSilently in the scope of the Auth0 client', async () => {
+    clientMock.getTokenSilently.mockReturnThis();
+    const wrapper = createWrapper();
+    const { waitForNextUpdate, result } = renderHook(
+      () => useContext(Auth0Context),
+      { wrapper }
+    );
+    await waitForNextUpdate();
+    const returnedThis = await result.current.getAccessTokenSilently();
+    expect(returnedThis).toStrictEqual(clientMock);
+  });
+
   it('should provide a getAccessTokenWithPopup method', async () => {
     clientMock.getTokenWithPopup.mockResolvedValue('token');
     const wrapper = createWrapper();
@@ -268,6 +280,18 @@ describe('Auth0Provider', () => {
     const token = await result.current.getAccessTokenWithPopup();
     expect(clientMock.getTokenWithPopup).toHaveBeenCalled();
     expect(token).toBe('token');
+  });
+
+  it('should call getAccessTokenWithPopup in the scope of the Auth0 client', async () => {
+    clientMock.getTokenWithPopup.mockReturnThis();
+    const wrapper = createWrapper();
+    const { waitForNextUpdate, result } = renderHook(
+      () => useContext(Auth0Context),
+      { wrapper }
+    );
+    await waitForNextUpdate();
+    const returnedThis = await result.current.getAccessTokenWithPopup();
+    expect(returnedThis).toStrictEqual(clientMock);
   });
 
   it('should normalize errors from getAccessTokenWithPopup method', async () => {

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -182,8 +182,12 @@ const Auth0Provider = ({
     <Auth0Context.Provider
       value={{
         ...state,
-        getAccessTokenSilently: wrappedGetToken(client.getTokenSilently),
-        getAccessTokenWithPopup: wrappedGetToken(client.getTokenWithPopup),
+        getAccessTokenSilently: wrappedGetToken((opts?) =>
+          client.getTokenSilently(opts)
+        ),
+        getAccessTokenWithPopup: wrappedGetToken((opts?) =>
+          client.getTokenWithPopup(opts)
+        ),
         getIdTokenClaims: (opts): Promise<IdToken> =>
           client.getIdTokenClaims(opts),
         loginWithRedirect: (opts): Promise<void> =>


### PR DESCRIPTION
### Description

Wrapping the token methods caused them to be called in the global scope when they should have been called in the scope of the `Auth0Client` instance

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
