### PR TITLE
Add extra options to withAuthenticationRequired

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,12 @@ Protect a route component using the `withAuthenticationRequired` higher order co
 import React from 'react';
 import { withAuthenticationRequired } from '@auth0/auth0-react';
 
-// Show a message while the user waits to be redirected to the login page.
-const Redirecting = () => <div>Redirecting you to the login page...</div>;
-
 const PrivateRoute = () => <div>Private</div>;
 
-export default withAuthenticationRequired(PrivateRoute, Redirecting);
+export default withAuthenticationRequired(PrivateRoute, {
+  // Show a message while the user waits to be redirected to the login page.
+  onRedirecting: () => <div>Redirecting you to the login page...</div>,
+});
 ```
 
 **Note** If you are using a custom router, you will need to supply the `Auth0Provider` with a custom `onRedirectCallback` method to perform the action that returns the user to the protected page. See examples for [react-router](https://github.com/auth0/auth0-react/blob/master/EXAMPLES.md#1-protecting-a-route-in-a-react-router-dom-app), [Gatsby](https://github.com/auth0/auth0-react/blob/master/EXAMPLES.md#2-protecting-a-route-in-a-gatsby-app) and [Next.js](https://github.com/auth0/auth0-react/blob/master/EXAMPLES.md#3-protecting-a-route-in-a-nextjs-app-in-spa-mode).

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,10 @@ export {
 } from './auth0-provider';
 export { default as useAuth0 } from './use-auth0';
 export { default as withAuth0, WithAuth0Props } from './with-auth0';
-export { default as withAuthenticationRequired } from './with-authentication-required';
+export {
+  default as withAuthenticationRequired,
+  WithAuthenticationRequiredOptions,
+} from './with-authentication-required';
 export {
   default as Auth0Context,
   Auth0ContextInterface,

--- a/typedoc.js
+++ b/typedoc.js
@@ -10,6 +10,7 @@ module.exports = {
     'Auth0ProviderOptions',
     'Auth0ContextInterface',
     'WithAuth0Props',
+    'WithAuthenticationRequiredOptions',
   ],
   mode: 'file',
   exclude: ['./src/utils.tsx', './src/reducer.tsx', './src/auth-state.tsx'],


### PR DESCRIPTION
### Description

There are some cases where just the `location.pathname` is not enough information for the user to be returned to the url they were redirected to the login page from. eg hashrouting

Allow the `returnTo` param to be customised as a string or a method to handle these cases, eg for hash routing:

```js
// A typical hash route will look like http://localhost:3000/#/users
withAuthenticationRequired(Users, {
  returnTo: () => window.location.hash.substr(1) // '/users'
})
```

Also allow the user to pass `RedirectLoginOptions` to `loginWithRedirect` in case they want to add additional `appState`

### References

https://github.com/auth0-samples/auth0-vue-samples/issues/100 (A Vue example, but the same applies to React)
https://reacttraining.com/react-router/web/api/HashRouter

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
