### PR TITLE
Update examples to have `returnTo` option set in logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,10 @@ function App() {
   if (isAuthenticated) {
     return (
       <div>
-        Hello {user.name} <button onClick={logout}>Log out</button>
+        Hello {user.name}{' '}
+        <button onClick={() => logout({ returnTo: window.location.origin })}>
+          Log out
+        </button>
       </div>
     );
   } else {

--- a/examples/cra-react-router/src/Nav.tsx
+++ b/examples/cra-react-router/src/Nav.tsx
@@ -39,7 +39,7 @@ export function Nav() {
           <button
             className="btn btn-outline-secondary"
             id="logout"
-            onClick={() => logout()}
+            onClick={() => logout({ returnTo: window.location.origin })}
           >
             logout
           </button>

--- a/examples/gatsby-app/src/components/Nav.js
+++ b/examples/gatsby-app/src/components/Nav.js
@@ -34,7 +34,7 @@ export function Nav() {
           <button
             className="btn btn-outline-secondary"
             id="logout"
-            onClick={() => logout()}
+            onClick={() => logout({ returnTo: window.location.origin })}
           >
             logout
           </button>

--- a/examples/nextjs-app/components/Nav.js
+++ b/examples/nextjs-app/components/Nav.js
@@ -50,7 +50,7 @@ export function Nav() {
           <button
             className="btn btn-outline-secondary"
             id="logout"
-            onClick={() => logout()}
+            onClick={() => logout({ returnTo: window.location.origin })}
           >
             logout
           </button>

--- a/src/auth0-context.tsx
+++ b/src/auth0-context.tsx
@@ -116,7 +116,7 @@ export interface Auth0ContextInterface extends AuthState {
 
   /**
    * ```js
-   * auth0.logout();
+   * auth0.logout({ returnTo: window.location.origin });
    * ```
    *
    * Clears the application session and performs a redirect to `/v2/logout`, using

--- a/static/index.html
+++ b/static/index.html
@@ -47,7 +47,11 @@
 
         return isAuthenticated ? (
           <div>
-            <button onClick={() => logout()}>logout</button>
+            <button
+              onClick={() => logout({ returnTo: window.location.origin })}
+            >
+              logout
+            </button>
             <button
               onClick={async () => setToken(await getAccessTokenSilently())}
             >


### PR DESCRIPTION
### Description

We recommend that people provide the `returnTo` argument to `logout`, otherwise they roll the dice with being returned to the first "allowed logout url" in the application's settings. 

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
