### PR TITLE
Fixed Typo

### DIFF
--- a/docs/interfaces/redirectloginoptions.html
+++ b/docs/interfaces/redirectloginoptions.html
@@ -2829,8 +2829,7 @@ img {
 				</aside>
 				<div class="tsd-comment tsd-typography">
 					<div class="lead">
-						<p>Used to store state before doing the redirect
-						Used to store state before doing the redirect</p>
+						<p>Used to store state before doing the redirect</p>
 					</div>
 				</div>
 			</section>


### PR DESCRIPTION
The text "Used to store state before doing the redirect" was duplicated

### Description

Simple Typo Fix