### PR TITLE
Add config argument to loginWithPopup

### DIFF
--- a/src/auth0-context.tsx
+++ b/src/auth0-context.tsx
@@ -6,6 +6,7 @@ import {
   IdToken,
   LogoutOptions,
   PopupLoginOptions,
+  PopupConfigOptions,
 } from '@auth0/auth0-spa-js';
 import { createContext } from 'react';
 import { AuthState, initialAuthState } from './auth-state';
@@ -100,7 +101,7 @@ export interface Auth0ContextInterface extends AuthState {
 
   /**
    * ```js
-   * await loginWithPopup(options);
+   * await loginWithPopup(options, config);
    * ```
    *
    * Opens a popup with the `/authorize` URL using the parameters
@@ -112,7 +113,10 @@ export interface Auth0ContextInterface extends AuthState {
    * that was started by the user like a button click, for example,
    * otherwise the popup will be blocked in most browsers.
    */
-  loginWithPopup: (options?: PopupLoginOptions) => Promise<void>;
+  loginWithPopup: (
+    options?: PopupLoginOptions,
+    config?: PopupConfigOptions
+  ) => Promise<void>;
 
   /**
    * ```js

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -5,6 +5,7 @@ import {
   CacheLocation,
   IdToken,
   PopupLoginOptions,
+  PopupConfigOptions,
   RedirectLoginOptions as Auth0RedirectLoginOptions,
 } from '@auth0/auth0-spa-js';
 import Auth0Context, { RedirectLoginOptions } from './auth0-context';
@@ -207,10 +208,13 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
     })();
   }, [client, onRedirectCallback]);
 
-  const loginWithPopup = async (options?: PopupLoginOptions): Promise<void> => {
+  const loginWithPopup = async (
+    options?: PopupLoginOptions,
+    config?: PopupConfigOptions
+  ): Promise<void> => {
     dispatch({ type: 'LOGIN_POPUP_STARTED' });
     try {
-      await client.loginWithPopup(options);
+      await client.loginWithPopup(options, config);
     } catch (error) {
       dispatch({ type: 'ERROR', error: loginError(error) });
       return;
@@ -234,7 +238,7 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
           client.getIdTokenClaims(opts),
         loginWithRedirect: (opts): Promise<void> =>
           client.loginWithRedirect(toAuth0LoginRedirectOptions(opts)),
-        loginWithPopup: (opts): Promise<void> => loginWithPopup(opts),
+        loginWithPopup,
         logout: (opts): void => client.logout(opts),
       }}
     >


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

`Auth0Client` provides a second argument `config` for `loginWithPopup` function. 

Unfortunately in `auth0-react` the second argument has been omitted.

### Testing

This change just redirects config argument to `Auth0Client` so no testing is needed.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
