### PR TITLE
Support react v16.11 (#96)

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,8 +89,8 @@
     "typescript": "^3.8.3"
   },
   "peerDependencies": {
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "react": "^16.11.0",
+    "react-dom": "^16.11.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
### Description

Support react and react-dom 16.11.

### References

https://github.com/auth0/auth0-react/issues/96

### Testing

I tested by changing these lines
https://github.com/auth0/auth0-react/blob/master/package.json#L75-L76
to 
```
    "react": "~16.11.0",
    "react-dom": "~16.11.0",
```
and running `npm test` (these all pass)

I reverted this because I figured it's better to test with 16.13 normally. Is there a different approach you'd like to take?

I tried setting up the integration tests but I ran into these kinds of errors:
```
Module not found: Can't resolve '@auth0/auth0-react' in ' ...
```

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
