### PR TITLE
duplicated getuser call removed

### DIFF
--- a/__tests__/auth-provider.test.tsx
+++ b/__tests__/auth-provider.test.tsx
@@ -77,7 +77,6 @@ describe('Auth0Provider', () => {
   });
 
   it('should check session when logged in', async () => {
-    clientMock.isAuthenticated.mockResolvedValue(true);
     clientMock.getUser.mockResolvedValue('__test_user__');
     const wrapper = createWrapper();
     const { waitForNextUpdate, result } = renderHook(
@@ -188,15 +187,15 @@ describe('Auth0Provider', () => {
   });
 
   it('should login with a popup', async () => {
-    clientMock.isAuthenticated.mockResolvedValue(false);
+    clientMock.getUser.mockResolvedValue(false);
     const wrapper = createWrapper();
     const { waitForNextUpdate, result } = renderHook(
       () => useContext(Auth0Context),
       { wrapper }
     );
     await waitForNextUpdate();
-    expect(result.current.isAuthenticated).toBe(false);
-    clientMock.isAuthenticated.mockResolvedValue(true);
+    expect(result.current.user).toBe(false);
+    clientMock.getUser.mockResolvedValue('__test_user__');
     act(() => {
       result.current.loginWithPopup();
     });
@@ -205,10 +204,11 @@ describe('Auth0Provider', () => {
     expect(result.current.isLoading).toBe(false);
     expect(clientMock.loginWithPopup).toHaveBeenCalled();
     expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.user).toBe('__test_user__');
   });
 
   it('should handle errors when logging in with a popup', async () => {
-    clientMock.isAuthenticated.mockResolvedValue(false);
+    clientMock.getUser.mockResolvedValue(false);
     const wrapper = createWrapper();
     const { waitForNextUpdate, result } = renderHook(
       () => useContext(Auth0Context),
@@ -216,7 +216,8 @@ describe('Auth0Provider', () => {
     );
     await waitForNextUpdate();
     expect(result.current.isAuthenticated).toBe(false);
-    clientMock.isAuthenticated.mockResolvedValue(false);
+    expect(result.current.user).toBe(false);
+    clientMock.getUser.mockResolvedValue(false);
     clientMock.loginWithPopup.mockRejectedValue(new Error('__test_error__'));
     act(() => {
       result.current.loginWithPopup();
@@ -226,6 +227,7 @@ describe('Auth0Provider', () => {
     expect(result.current.isLoading).toBe(false);
     expect(clientMock.loginWithPopup).toHaveBeenCalled();
     expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.user).toBe(false);
     expect(() => {
       throw result.current.error;
     }).toThrowError('__test_error__');
@@ -248,7 +250,7 @@ describe('Auth0Provider', () => {
   });
 
   it('should provide a logout method', async () => {
-    clientMock.isAuthenticated.mockResolvedValue(true);
+    clientMock.getUser.mockResolvedValue('__test_user__');
     const wrapper = createWrapper();
     const { waitForNextUpdate, result } = renderHook(
       () => useContext(Auth0Context),
@@ -262,10 +264,10 @@ describe('Auth0Provider', () => {
     expect(clientMock.logout).toHaveBeenCalled();
     // Should not update state until returned from idp
     expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.user).toBe('__test_user__');
   });
 
   it('should update state for local logouts', async () => {
-    clientMock.isAuthenticated.mockResolvedValue(true);
     clientMock.getUser.mockResolvedValue('__test_user__');
     const wrapper = createWrapper();
     const { waitForNextUpdate, result } = renderHook(

--- a/__tests__/with-authentication-required.test.tsx
+++ b/__tests__/with-authentication-required.test.tsx
@@ -10,7 +10,7 @@ const mockClient = mocked(new Auth0Client({ client_id: '', domain: '' }));
 
 describe('withAuthenticationRequired', () => {
   it('should block access to a private component when not authenticated', async () => {
-    mockClient.isAuthenticated.mockResolvedValue(false);
+    mockClient.getUser.mockResolvedValue(false);
     const MyComponent = (): JSX.Element => <>Private</>;
     const WrappedComponent = withAuthenticationRequired(MyComponent);
     render(
@@ -25,7 +25,7 @@ describe('withAuthenticationRequired', () => {
   });
 
   it('should allow access to a private component when authenticated', async () => {
-    mockClient.isAuthenticated.mockResolvedValue(true);
+    mockClient.getUser.mockResolvedValue('__test_user__');
     const MyComponent = (): JSX.Element => <>Private</>;
     const WrappedComponent = withAuthenticationRequired(MyComponent);
     render(
@@ -40,7 +40,7 @@ describe('withAuthenticationRequired', () => {
   });
 
   it('should show a custom redirecting message', async () => {
-    mockClient.isAuthenticated.mockResolvedValue(true);
+    mockClient.getUser.mockResolvedValue('__test_user__');
     const MyComponent = (): JSX.Element => <>Private</>;
     const OnRedirecting = (): JSX.Element => <>Redirecting</>;
     const WrappedComponent = withAuthenticationRequired(MyComponent, {
@@ -61,7 +61,7 @@ describe('withAuthenticationRequired', () => {
   });
 
   it('should pass additional options on to loginWithRedirect', async () => {
-    mockClient.isAuthenticated.mockResolvedValue(false);
+    mockClient.getUser.mockResolvedValue(false);
     const MyComponent = (): JSX.Element => <>Private</>;
     const WrappedComponent = withAuthenticationRequired(MyComponent, {
       loginOptions: {
@@ -83,7 +83,7 @@ describe('withAuthenticationRequired', () => {
   });
 
   it('should merge additional appState with the returnTo', async () => {
-    mockClient.isAuthenticated.mockResolvedValue(false);
+    mockClient.getUser.mockResolvedValue(false);
     const MyComponent = (): JSX.Element => <>Private</>;
     const WrappedComponent = withAuthenticationRequired(MyComponent, {
       loginOptions: {
@@ -111,7 +111,7 @@ describe('withAuthenticationRequired', () => {
   });
 
   it('should accept a returnTo function', async () => {
-    mockClient.isAuthenticated.mockResolvedValue(false);
+    mockClient.getUser.mockResolvedValue(false);
     const MyComponent = (): JSX.Element => <>Private</>;
     const WrappedComponent = withAuthenticationRequired(MyComponent, {
       returnTo: () => '/foo',

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -200,9 +200,8 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
         } else {
           await client.checkSession();
         }
-        const isAuthenticated = await client.isAuthenticated();
-        const user = isAuthenticated && (await client.getUser());
-        dispatch({ type: 'INITIALISED', isAuthenticated, user });
+        const user = await client.getUser();
+        dispatch({ type: 'INITIALISED', isAuthenticated: !!user, user });
       } catch (error) {
         dispatch({ type: 'ERROR', error: loginError(error) });
       }
@@ -220,9 +219,8 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
       dispatch({ type: 'ERROR', error: loginError(error) });
       return;
     }
-    const isAuthenticated = await client.isAuthenticated();
-    const user = isAuthenticated && (await client.getUser());
-    dispatch({ type: 'LOGIN_POPUP_COMPLETE', isAuthenticated, user });
+    const user = await client.getUser();
+    dispatch({ type: 'LOGIN_POPUP_COMPLETE', isAuthenticated: !!user, user });
   };
 
   const logout = (opts: LogoutOptions = {}): void => {


### PR DESCRIPTION
### Description

Duplicated getUser call removed from Auth0Provider, tests that depend on isAuthenticated Auth0Client method are updated.

### References

https://github.com/auth0/auth0-react/issues/103

### Testing

Test are updated and passing.

### Checklist

- [ ] No documentation is needed.
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
