### PR TITLE
[SDK-1927] Check for state param in callback url

### DIFF
--- a/__tests__/utils.test.tsx
+++ b/__tests__/utils.test.tsx
@@ -2,10 +2,19 @@ import { hasAuthParams, loginError, tokenError } from '../src/utils';
 import { OAuthError } from '../src/errors';
 
 describe('utils hasAuthParams', () => {
-  it('should recognise the code param', async () => {
+  it('should not recognise only the code param', async () => {
     ['?code=1', '?foo=1&code=2', '?code=1&foo=2'].forEach((search) =>
-      expect(hasAuthParams(search)).toBeTruthy()
+      expect(hasAuthParams(search)).toBeFalsy()
     );
+  });
+
+  it('should recognise the code and state param', async () => {
+    [
+      '?code=1&state=2',
+      '?foo=1&state=2&code=3',
+      '?code=1&foo=2&state=3',
+      '?state=1&code=2&foo=3',
+    ].forEach((search) => expect(hasAuthParams(search)).toBeTruthy());
   });
 
   it('should recognise the error param', async () => {

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -5,10 +5,12 @@ import {
 import { OAuthError } from './errors';
 
 const CODE_RE = /[?&]code=[^&]+/;
+const STATE_RE = /[?&]state=[^&]+/;
 const ERROR_RE = /[?&]error=[^&]+/;
 
 export const hasAuthParams = (searchParams = window.location.search): boolean =>
-  CODE_RE.test(searchParams) || ERROR_RE.test(searchParams);
+  (CODE_RE.test(searchParams) && STATE_RE.test(searchParams)) ||
+  ERROR_RE.test(searchParams);
 
 const normalizeErrorFn = (fallbackMessage: string) => (
   error: Error | { error: string; error_description?: string } | ProgressEvent


### PR DESCRIPTION
### Description

Because SPA JS always sends a `state` param to `/authorize`, we can always assume that a valid redirect callback will contain both `state` and `code`. 

Doing this will reduce the chance of collisions when the application is using the `code` param for something unrelated to auth.

### References

Might mitigate some cases of #75 

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
