### PR TITLE
Export AppState type for custom onRedirectCallback's

### DIFF
--- a/examples/cra-react-router/src/index.tsx
+++ b/examples/cra-react-router/src/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App, { history } from './App';
-import { Auth0Provider } from '@auth0/auth0-react';
+import { Auth0Provider, AppState } from '@auth0/auth0-react';
 
-const onRedirectCallback = (appState: any) => {
+const onRedirectCallback = (appState: AppState) => {
   // If using a Hash Router, you need to use window.history.replaceState to
   // remove the `code` and `state` query parameters from the callback url.
   // window.history.replaceState({}, document.title, window.location.pathname);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 export {
   default as Auth0Provider,
   Auth0ProviderOptions,
+  AppState,
 } from './auth0-provider';
 export { default as useAuth0 } from './use-auth0';
 export { default as withAuth0, WithAuth0Props } from './with-auth0';


### PR DESCRIPTION
Export `AppState` type so it can be used in custom `onRedirectCallback`'s

See https://github.com/auth0/auth0-react/blob/a4c5f675217ebfbd36b8c2245b7f1a36c2db4b0d/examples/cra-react-router/src/index.tsx#L4-L11

## Refrences

Fixes #119