### PR TITLE
Add bundle analysis output when running build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7846,6 +7846,12 @@
         "fsevents": "~2.1.2"
       }
     },
+    "rollup-plugin-analyzer": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-analyzer/-/rollup-plugin-analyzer-3.3.0.tgz",
+      "integrity": "sha512-zUPGitW4usmZcVa0nKecRvw3odtXgnxdCben9Hx1kxVoR3demek8RU9tmRG/R35hnRPQTb7wEsYEe3GUcjxIMA==",
+      "dev": true
+    },
     "rollup-plugin-delete": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-delete/-/rollup-plugin-delete-1.2.0.tgz",
@@ -9203,9 +9209,9 @@
       }
     },
     "unfetch": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.1.0.tgz",
-      "integrity": "sha512-crP/n3eAPUJxZXM9T80/yv0YhkTEx2K1D3h7D1AJM6fzsWZrxdyRuLN0JH/dkZh1LNH8LxCnBzoPFCPbb2iGpg=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "react-dom": "^16.13.1",
     "react-test-renderer": "^16.13.1",
     "rollup": "^2.7.2",
+    "rollup-plugin-analyzer": "^3.3.0",
     "rollup-plugin-delete": "^1.2.0",
     "rollup-plugin-livereload": "^1.2.0",
     "rollup-plugin-peer-deps-external": "^2.2.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,6 +7,7 @@ import { terser } from 'rollup-plugin-terser';
 import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 import pkg from './package.json';
+import analyze from 'rollup-plugin-analyzer';
 
 const isProduction = process.env.NODE_ENV === 'production';
 const name = 'reactAuth0';
@@ -21,6 +22,7 @@ const plugins = [
   external(),
   resolve(),
   replace({ __VERSION__: `'${pkg.version}'` }),
+  analyze({ summaryOnly: true }),
 ];
 
 export default [


### PR DESCRIPTION
When running `npm run build`, rollup will output information about our bundle size. This is a first step to get better insight into our bundle size.