### PR TITLE
Add config argument to getAccessTokenWithPopup

### DIFF
--- a/src/auth0-context.tsx
+++ b/src/auth0-context.tsx
@@ -65,7 +65,7 @@ export interface Auth0ContextInterface extends AuthState {
 
   /**
    * ```js
-   * const token = await getTokenWithPopup(options);
+   * const token = await getTokenWithPopup(options, config);
    * ```
    *
    * Get an access token interactively.
@@ -76,7 +76,8 @@ export interface Auth0ContextInterface extends AuthState {
    * results will be valid according to their expiration times.
    */
   getAccessTokenWithPopup: (
-    options?: GetTokenWithPopupOptions
+    options?: GetTokenWithPopupOptions,
+    config?: PopupConfigOptions
   ) => Promise<string>;
 
   /**

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -8,6 +8,7 @@ import {
   PopupLoginOptions,
   PopupConfigOptions,
   RedirectLoginOptions as Auth0RedirectLoginOptions,
+  GetTokenWithPopupOptions,
 } from '@auth0/auth0-spa-js';
 import Auth0Context, { RedirectLoginOptions } from './auth0-context';
 import { hasAuthParams, loginError, wrappedGetToken } from './utils';
@@ -237,8 +238,9 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
         getAccessTokenSilently: wrappedGetToken((opts?) =>
           client.getTokenSilently(opts)
         ),
-        getAccessTokenWithPopup: wrappedGetToken((opts?) =>
-          client.getTokenWithPopup(opts)
+        getAccessTokenWithPopup: wrappedGetToken(
+          (opts?: GetTokenWithPopupOptions, config?: PopupConfigOptions) =>
+            client.getTokenWithPopup(opts, config)
         ),
         getIdTokenClaims: (opts): Promise<IdToken> =>
           client.getIdTokenClaims(opts),


### PR DESCRIPTION
### Description

Add workaround config argument to getAccessTokenWithPopup to work with iOS, similar to loginWithPopup.

### References

https://github.com/auth0/auth0-spa-js/pull/368

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
