### PR TITLE
Update the user/isAuthenticated state after getting a token

### DIFF
--- a/__tests__/auth-provider.test.tsx
+++ b/__tests__/auth-provider.test.tsx
@@ -296,9 +296,12 @@ describe('Auth0Provider', () => {
     );
     await waitForNextUpdate();
     expect(result.current.getAccessTokenSilently).toBeInstanceOf(Function);
-    const token = await result.current.getAccessTokenSilently();
+    await act(async () => {
+      const token = await result.current.getAccessTokenSilently();
+      expect(token).toBe('token');
+    });
+
     expect(clientMock.getTokenSilently).toHaveBeenCalled();
-    expect(token).toBe('token');
   });
 
   it('should normalize errors from getAccessTokenSilently method', async () => {
@@ -322,8 +325,29 @@ describe('Auth0Provider', () => {
       { wrapper }
     );
     await waitForNextUpdate();
-    const returnedThis = await result.current.getAccessTokenSilently();
-    expect(returnedThis).toStrictEqual(clientMock);
+
+    await act(async () => {
+      const returnedThis = await result.current.getAccessTokenSilently();
+      expect(returnedThis).toStrictEqual(clientMock);
+    });
+  });
+
+  it('should update auth state after getAccessTokenSilently', async () => {
+    clientMock.getTokenSilently.mockReturnThis();
+    clientMock.getUser.mockResolvedValue('foo');
+    const wrapper = createWrapper();
+    const { waitForNextUpdate, result } = renderHook(
+      () => useContext(Auth0Context),
+      { wrapper }
+    );
+    await waitForNextUpdate();
+
+    expect(result.current.user).toEqual('foo');
+    clientMock.getUser.mockResolvedValue('bar');
+    await act(async () => {
+      await result.current.getAccessTokenSilently();
+    });
+    expect(result.current.user).toEqual('bar');
   });
 
   it('should provide a getAccessTokenWithPopup method', async () => {
@@ -335,9 +359,11 @@ describe('Auth0Provider', () => {
     );
     await waitForNextUpdate();
     expect(result.current.getAccessTokenWithPopup).toBeInstanceOf(Function);
-    const token = await result.current.getAccessTokenWithPopup();
+    await act(async () => {
+      const token = await result.current.getAccessTokenWithPopup();
+      expect(token).toBe('token');
+    });
     expect(clientMock.getTokenWithPopup).toHaveBeenCalled();
-    expect(token).toBe('token');
   });
 
   it('should call getAccessTokenWithPopup in the scope of the Auth0 client', async () => {
@@ -348,8 +374,28 @@ describe('Auth0Provider', () => {
       { wrapper }
     );
     await waitForNextUpdate();
-    const returnedThis = await result.current.getAccessTokenWithPopup();
-    expect(returnedThis).toStrictEqual(clientMock);
+    await act(async () => {
+      const returnedThis = await result.current.getAccessTokenWithPopup();
+      expect(returnedThis).toStrictEqual(clientMock);
+    });
+  });
+
+  it('should update auth state after getAccessTokenWithPopup', async () => {
+    clientMock.getTokenSilently.mockReturnThis();
+    clientMock.getUser.mockResolvedValue('foo');
+    const wrapper = createWrapper();
+    const { waitForNextUpdate, result } = renderHook(
+      () => useContext(Auth0Context),
+      { wrapper }
+    );
+    await waitForNextUpdate();
+
+    expect(result.current.isAuthenticated).toEqual(true);
+    clientMock.getUser.mockResolvedValue(false);
+    await act(async () => {
+      await result.current.getAccessTokenSilently();
+    });
+    expect(result.current.isAuthenticated).toEqual(false);
   });
 
   it('should normalize errors from getAccessTokenWithPopup method', async () => {

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -9,9 +9,10 @@ import {
   PopupConfigOptions,
   RedirectLoginOptions as Auth0RedirectLoginOptions,
   GetTokenWithPopupOptions,
+  GetTokenSilentlyOptions,
 } from '@auth0/auth0-spa-js';
 import Auth0Context, { RedirectLoginOptions } from './auth0-context';
-import { hasAuthParams, loginError, wrappedGetToken } from './utils';
+import { hasAuthParams, loginError, tokenError } from './utils';
 import { reducer } from './reducer';
 import { initialAuthState } from './auth-state';
 
@@ -202,7 +203,7 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
           await client.checkSession();
         }
         const user = await client.getUser();
-        dispatch({ type: 'INITIALISED', isAuthenticated: !!user, user });
+        dispatch({ type: 'INITIALISED', user });
       } catch (error) {
         dispatch({ type: 'ERROR', error: loginError(error) });
       }
@@ -221,7 +222,7 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
       return;
     }
     const user = await client.getUser();
-    dispatch({ type: 'LOGIN_POPUP_COMPLETE', isAuthenticated: !!user, user });
+    dispatch({ type: 'LOGIN_POPUP_COMPLETE', user });
   };
 
   const logout = (opts: LogoutOptions = {}): void => {
@@ -231,17 +232,41 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
     }
   };
 
+  const getAccessTokenSilently = async (
+    opts?: GetTokenSilentlyOptions
+  ): Promise<string> => {
+    let token;
+    try {
+      token = await client.getTokenSilently(opts);
+    } catch (error) {
+      throw tokenError(error);
+    }
+    const user = await client.getUser();
+    dispatch({ type: 'GET_TOKEN_COMPLETE', user });
+    return token;
+  };
+
+  const getAccessTokenWithPopup = async (
+    opts?: GetTokenWithPopupOptions,
+    config?: PopupConfigOptions
+  ): Promise<string> => {
+    let token;
+    try {
+      token = await client.getTokenWithPopup(opts, config);
+    } catch (error) {
+      throw tokenError(error);
+    }
+    const user = await client.getUser();
+    dispatch({ type: 'GET_TOKEN_COMPLETE', user });
+    return token;
+  };
+
   return (
     <Auth0Context.Provider
       value={{
         ...state,
-        getAccessTokenSilently: wrappedGetToken((opts?) =>
-          client.getTokenSilently(opts)
-        ),
-        getAccessTokenWithPopup: wrappedGetToken(
-          (opts?: GetTokenWithPopupOptions, config?: PopupConfigOptions) =>
-            client.getTokenWithPopup(opts, config)
-        ),
+        getAccessTokenSilently,
+        getAccessTokenWithPopup,
         getIdTokenClaims: (opts): Promise<IdToken> =>
           client.getIdTokenClaims(opts),
         loginWithRedirect: (opts): Promise<void> =>

--- a/src/reducer.tsx
+++ b/src/reducer.tsx
@@ -3,8 +3,7 @@ import { AuthState, User } from './auth-state';
 type Action =
   | { type: 'LOGIN_POPUP_STARTED' }
   | {
-      type: 'INITIALISED' | 'LOGIN_POPUP_COMPLETE';
-      isAuthenticated: boolean;
+      type: 'INITIALISED' | 'LOGIN_POPUP_COMPLETE' | 'GET_TOKEN_COMPLETE';
       user?: User;
     }
   | { type: 'LOGOUT' }
@@ -24,10 +23,16 @@ export const reducer = (state: AuthState, action: Action): AuthState => {
     case 'INITIALISED':
       return {
         ...state,
-        isAuthenticated: action.isAuthenticated,
+        isAuthenticated: !!action.user,
         user: action.user,
         isLoading: false,
         error: undefined,
+      };
+    case 'GET_TOKEN_COMPLETE':
+      return {
+        ...state,
+        isAuthenticated: !!action.user,
+        user: action.user,
       };
     case 'LOGOUT':
       return {

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,7 +1,3 @@
-import {
-  GetTokenSilentlyOptions,
-  GetTokenWithPopupOptions,
-} from '@auth0/auth0-spa-js';
 import { OAuthError } from './errors';
 
 const CODE_RE = /[?&]code=[^&]+/;
@@ -27,17 +23,3 @@ const normalizeErrorFn = (fallbackMessage: string) => (
 export const loginError = normalizeErrorFn('Login failed');
 
 export const tokenError = normalizeErrorFn('Get access token failed');
-
-export const wrappedGetToken = (
-  getTokenFn: (
-    opts?: GetTokenSilentlyOptions | GetTokenWithPopupOptions
-  ) => Promise<string>
-) => async (
-  opts?: GetTokenSilentlyOptions | GetTokenWithPopupOptions
-): Promise<string> => {
-  try {
-    return await getTokenFn(opts);
-  } catch (error) {
-    throw tokenError(error);
-  }
-};


### PR DESCRIPTION
### Description

Everytime we call `getAccessToken*`, update the `user` from the spa client - since it may have been updated.

With the caveat that, if you're relying on the user as a dependant key of some memoized operation, the reference to the user might change when the user properties haven't. eg

```js
// DON'T
useEffect(() => {
  (async () => {
    setProfile(await fetch(`/profile/{user.sub}`));
  })()
}, [user]) // <= ref might change

// DO
useEffect(() => {
  (async () => {
    setProfile(await fetch(`/profile/{user.sub}`));
  })()
}, [user.sub]) // <= primitive won't change
```

### References

Fixes #109 

### Testing

Given I login to the auth0-react playground
And I update the user's claims
When I click `getAccessTokenSilently`
Then the user's claims should be updated

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
