### PR TITLE
[SDK-2106] Memoize auth methods

### DIFF
--- a/__tests__/auth-provider.test.tsx
+++ b/__tests__/auth-provider.test.tsx
@@ -457,4 +457,16 @@ describe('Auth0Provider', () => {
       __raw: '__test_raw_token__',
     });
   });
+
+  it('should memoize the getIdTokenClaims method', async () => {
+    const wrapper = createWrapper();
+    const { waitForNextUpdate, result, rerender } = renderHook(
+      () => useContext(Auth0Context),
+      { wrapper }
+    );
+    await waitForNextUpdate();
+    const memoized = result.current.getIdTokenClaims;
+    rerender();
+    expect(result.current.getIdTokenClaims).toBe(memoized);
+  });
 });

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useReducer, useState } from 'react';
+import React, { useCallback, useEffect, useReducer, useState } from 'react';
 import {
   Auth0Client,
   Auth0ClientOptions,
@@ -15,6 +15,7 @@ import Auth0Context, { RedirectLoginOptions } from './auth0-context';
 import { hasAuthParams, loginError, tokenError } from './utils';
 import { reducer } from './reducer';
 import { initialAuthState } from './auth-state';
+import { GetIdTokenClaimsOptions } from '@auth0/auth0-spa-js/src/global';
 
 /**
  * The state of the application before the user was redirected to the login page.
@@ -225,56 +226,78 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
     })();
   }, [client, onRedirectCallback, skipRedirectCallback]);
 
-  const loginWithPopup = async (
-    options?: PopupLoginOptions,
-    config?: PopupConfigOptions
-  ): Promise<void> => {
-    dispatch({ type: 'LOGIN_POPUP_STARTED' });
-    try {
-      await client.loginWithPopup(options, config);
-    } catch (error) {
-      dispatch({ type: 'ERROR', error: loginError(error) });
-      return;
-    }
-    const user = await client.getUser();
-    dispatch({ type: 'LOGIN_POPUP_COMPLETE', user });
-  };
+  const loginWithRedirect = useCallback(
+    (opts?: Auth0RedirectLoginOptions): Promise<void> =>
+      client.loginWithRedirect(toAuth0LoginRedirectOptions(opts)),
+    [client]
+  );
 
-  const logout = (opts: LogoutOptions = {}): void => {
-    client.logout(opts);
-    if (opts.localOnly) {
-      dispatch({ type: 'LOGOUT' });
-    }
-  };
+  const loginWithPopup = useCallback(
+    async (
+      options?: PopupLoginOptions,
+      config?: PopupConfigOptions
+    ): Promise<void> => {
+      dispatch({ type: 'LOGIN_POPUP_STARTED' });
+      try {
+        await client.loginWithPopup(options, config);
+      } catch (error) {
+        dispatch({ type: 'ERROR', error: loginError(error) });
+        return;
+      }
+      const user = await client.getUser();
+      dispatch({ type: 'LOGIN_POPUP_COMPLETE', user });
+    },
+    [client]
+  );
 
-  const getAccessTokenSilently = async (
-    opts?: GetTokenSilentlyOptions
-  ): Promise<string> => {
-    let token;
-    try {
-      token = await client.getTokenSilently(opts);
-    } catch (error) {
-      throw tokenError(error);
-    }
-    const user = await client.getUser();
-    dispatch({ type: 'GET_TOKEN_COMPLETE', user });
-    return token;
-  };
+  const logout = useCallback(
+    (opts: LogoutOptions = {}): void => {
+      client.logout(opts);
+      if (opts.localOnly) {
+        dispatch({ type: 'LOGOUT' });
+      }
+    },
+    [client]
+  );
 
-  const getAccessTokenWithPopup = async (
-    opts?: GetTokenWithPopupOptions,
-    config?: PopupConfigOptions
-  ): Promise<string> => {
-    let token;
-    try {
-      token = await client.getTokenWithPopup(opts, config);
-    } catch (error) {
-      throw tokenError(error);
-    }
-    const user = await client.getUser();
-    dispatch({ type: 'GET_TOKEN_COMPLETE', user });
-    return token;
-  };
+  const getAccessTokenSilently = useCallback(
+    async (opts?: GetTokenSilentlyOptions): Promise<string> => {
+      let token;
+      try {
+        token = await client.getTokenSilently(opts);
+      } catch (error) {
+        throw tokenError(error);
+      }
+      const user = await client.getUser();
+      dispatch({ type: 'GET_TOKEN_COMPLETE', user });
+      return token;
+    },
+    [client]
+  );
+
+  const getAccessTokenWithPopup = useCallback(
+    async (
+      opts?: GetTokenWithPopupOptions,
+      config?: PopupConfigOptions
+    ): Promise<string> => {
+      let token;
+      try {
+        token = await client.getTokenWithPopup(opts, config);
+      } catch (error) {
+        throw tokenError(error);
+      }
+      const user = await client.getUser();
+      dispatch({ type: 'GET_TOKEN_COMPLETE', user });
+      return token;
+    },
+    [client]
+  );
+
+  const getIdTokenClaims = useCallback(
+    (opts?: GetIdTokenClaimsOptions): Promise<IdToken> =>
+      client.getIdTokenClaims(opts),
+    [client]
+  );
 
   return (
     <Auth0Context.Provider
@@ -282,10 +305,8 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
         ...state,
         getAccessTokenSilently,
         getAccessTokenWithPopup,
-        getIdTokenClaims: (opts): Promise<IdToken> =>
-          client.getIdTokenClaims(opts),
-        loginWithRedirect: (opts): Promise<void> =>
-          client.loginWithRedirect(toAuth0LoginRedirectOptions(opts)),
+        getIdTokenClaims,
+        loginWithRedirect,
         loginWithPopup,
         logout,
       }}

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -10,12 +10,12 @@ import {
   RedirectLoginOptions as Auth0RedirectLoginOptions,
   GetTokenWithPopupOptions,
   GetTokenSilentlyOptions,
+  GetIdTokenClaimsOptions,
 } from '@auth0/auth0-spa-js';
 import Auth0Context, { RedirectLoginOptions } from './auth0-context';
 import { hasAuthParams, loginError, tokenError } from './utils';
 import { reducer } from './reducer';
 import { initialAuthState } from './auth-state';
-import { GetIdTokenClaimsOptions } from '@auth0/auth0-spa-js/src/global';
 
 /**
  * The state of the application before the user was redirected to the login page.


### PR DESCRIPTION
~~(will base on `master` after #146 is merged)~~

### Description

Memoizing the auth methods means that downstream components that use them in dependent keys of other hooks wont get unnecessary updates when auth state changes.

*Easier to review if you hide whitespace changes https://github.com/auth0/auth0-react/pull/150/files?w=1

### References

Fixes #131 

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
