### PR TITLE
fix: add react fast refresh support

### DIFF
--- a/src/with-authentication-required.tsx
+++ b/src/with-authentication-required.tsx
@@ -73,31 +73,33 @@ export interface WithAuthenticationRequiredOptions {
 const withAuthenticationRequired = <P extends object>(
   Component: ComponentType<P>,
   options: WithAuthenticationRequiredOptions = {}
-): FC<P> => (props: P): JSX.Element => {
-  const { isAuthenticated, isLoading, loginWithRedirect } = useAuth0();
-  const {
-    returnTo = defaultReturnTo,
-    onRedirecting = defaultOnRedirecting,
-    loginOptions = {},
-  } = options;
+): FC<P> => {
+  return function WithAuthenticationRequired(props: P): JSX.Element {
+    const { isAuthenticated, isLoading, loginWithRedirect } = useAuth0();
+    const {
+      returnTo = defaultReturnTo,
+      onRedirecting = defaultOnRedirecting,
+      loginOptions = {},
+    } = options;
 
-  useEffect(() => {
-    if (isLoading || isAuthenticated) {
-      return;
-    }
-    const opts = {
-      ...loginOptions,
-      appState: {
-        ...loginOptions.appState,
-        returnTo: typeof returnTo === 'function' ? returnTo() : returnTo,
-      },
-    };
-    (async (): Promise<void> => {
-      await loginWithRedirect(opts);
-    })();
-  }, [isLoading, isAuthenticated, loginWithRedirect, loginOptions, returnTo]);
+    useEffect(() => {
+      if (isLoading || isAuthenticated) {
+        return;
+      }
+      const opts = {
+        ...loginOptions,
+        appState: {
+          ...loginOptions.appState,
+          returnTo: typeof returnTo === 'function' ? returnTo() : returnTo,
+        },
+      };
+      (async (): Promise<void> => {
+        await loginWithRedirect(opts);
+      })();
+    }, [isLoading, isAuthenticated, loginWithRedirect, loginOptions, returnTo]);
 
-  return isAuthenticated ? <Component {...props} /> : onRedirecting();
-};
+    return isAuthenticated ? <Component {...props} /> : onRedirecting();
+  };
+}
 
 export default withAuthenticationRequired;


### PR DESCRIPTION
### Description

> React Fast Refresh is now used by default in Next.js 10. RFR require named components, otherwise it will reload whole page. This is a small fix that replaces unnamed arrow function with named function.

### Testing

This can be tested by bootstraping next.js project and setting up this package. Wrapping any page export with `withAuthenticationRequired` should result in smooth content refresh after change.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`

Btw: it would be cool to get this accepted as hacktoberfest PR, thanks!