### PR TITLE
add screen_hint to redirectloginoptions docs

### DIFF
--- a/docs/interfaces/redirectloginoptions.html
+++ b/docs/interfaces/redirectloginoptions.html
@@ -2796,8 +2796,8 @@ img {
 							<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-overwrite tsd-is-inherited"><a href="redirectloginoptions.html#prompt" class="tsd-kind-icon">prompt</a></li>
 							<li class="tsd-kind-property tsd-parent-kind-interface"><a href="redirectloginoptions.html#redirecturi" class="tsd-kind-icon">redirect<wbr>Uri</a></li>
 							<li class="tsd-kind-property tsd-parent-kind-interface"><a href="redirectloginoptions.html#redirect_uri" class="tsd-kind-icon">redirect_<wbr>uri</a></li>
-              						<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-overwrite tsd-is-inherited"><a href="redirectloginoptions.html#scope" class="tsd-kind-icon">scope</a></li>
-              						<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-overwrite tsd-is-inherited"><a href="redirectloginoptions.html#screen_hint" class="tsd-kind-icon">screen_hint</a></li>
+              					<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-overwrite tsd-is-inherited"><a href="redirectloginoptions.html#scope" class="tsd-kind-icon">scope</a></li>
+              					<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-overwrite tsd-is-inherited"><a href="redirectloginoptions.html#screen_hint" class="tsd-kind-icon">screen_hint</a></li>
 							<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-overwrite tsd-is-inherited"><a href="redirectloginoptions.html#ui_locales" class="tsd-kind-icon">ui_<wbr>locales</a></li>
 						</ul>
 					</section>

--- a/docs/interfaces/redirectloginoptions.html
+++ b/docs/interfaces/redirectloginoptions.html
@@ -2796,8 +2796,8 @@ img {
 							<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-overwrite tsd-is-inherited"><a href="redirectloginoptions.html#prompt" class="tsd-kind-icon">prompt</a></li>
 							<li class="tsd-kind-property tsd-parent-kind-interface"><a href="redirectloginoptions.html#redirecturi" class="tsd-kind-icon">redirect<wbr>Uri</a></li>
 							<li class="tsd-kind-property tsd-parent-kind-interface"><a href="redirectloginoptions.html#redirect_uri" class="tsd-kind-icon">redirect_<wbr>uri</a></li>
-              <li class="tsd-kind-property tsd-parent-kind-interface tsd-is-overwrite tsd-is-inherited"><a href="redirectloginoptions.html#scope" class="tsd-kind-icon">scope</a></li>
-              <li class="tsd-kind-property tsd-parent-kind-interface tsd-is-overwrite tsd-is-inherited"><a href="redirectloginoptions.html#screen_hint" class="tsd-kind-icon">screen_hint</a></li>
+              						<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-overwrite tsd-is-inherited"><a href="redirectloginoptions.html#scope" class="tsd-kind-icon">scope</a></li>
+              						<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-overwrite tsd-is-inherited"><a href="redirectloginoptions.html#screen_hint" class="tsd-kind-icon">screen_hint</a></li>
 							<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-overwrite tsd-is-inherited"><a href="redirectloginoptions.html#ui_locales" class="tsd-kind-icon">ui_<wbr>locales</a></li>
 						</ul>
 					</section>
@@ -3042,8 +3042,8 @@ img {
 						along with this scope</p>
 					</div>
 				</div>
-      </section>
-      <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-overwrite tsd-is-inherited">
+		      </section>
+		      <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-overwrite tsd-is-inherited">
 				<a name="screen_hint" class="tsd-anchor"></a>
 				<h3><span class="tsd-flag ts-flagOptional">Optional</span> screen_hint</h3>
 				<div class="tsd-signature tsd-kind-icon">screen_hint<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"login"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"signup"</span><span class="tsd-signature-symbol"></div>
@@ -3056,11 +3056,11 @@ img {
 				</aside>
 				<div class="tsd-comment tsd-typography">
 					<div class="lead">
-            <p>The form to show when a user is redirected to the Auth0 Universal Login page.</p>
-            <li><code>&#39;login&#39;</code>: (default) shows the login form</li>
+			    			<p>The form to show when a user is redirected to the Auth0 Universal Login page.</p>
+			    			<li><code>&#39;login&#39;</code>: (default) shows the login form</li>
 						<li><code>&#39;singup&#39;</code>: shows the signup form</li>
 					</div>
-        </div>
+				</div>
 			</section>
 			<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-overwrite tsd-is-inherited">
 				<a name="ui_locales" class="tsd-anchor"></a>

--- a/docs/interfaces/redirectloginoptions.html
+++ b/docs/interfaces/redirectloginoptions.html
@@ -2796,7 +2796,8 @@ img {
 							<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-overwrite tsd-is-inherited"><a href="redirectloginoptions.html#prompt" class="tsd-kind-icon">prompt</a></li>
 							<li class="tsd-kind-property tsd-parent-kind-interface"><a href="redirectloginoptions.html#redirecturi" class="tsd-kind-icon">redirect<wbr>Uri</a></li>
 							<li class="tsd-kind-property tsd-parent-kind-interface"><a href="redirectloginoptions.html#redirect_uri" class="tsd-kind-icon">redirect_<wbr>uri</a></li>
-							<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-overwrite tsd-is-inherited"><a href="redirectloginoptions.html#scope" class="tsd-kind-icon">scope</a></li>
+              <li class="tsd-kind-property tsd-parent-kind-interface tsd-is-overwrite tsd-is-inherited"><a href="redirectloginoptions.html#scope" class="tsd-kind-icon">scope</a></li>
+              <li class="tsd-kind-property tsd-parent-kind-interface tsd-is-overwrite tsd-is-inherited"><a href="redirectloginoptions.html#screen_hint" class="tsd-kind-icon">screen_hint</a></li>
 							<li class="tsd-kind-property tsd-parent-kind-interface tsd-is-overwrite tsd-is-inherited"><a href="redirectloginoptions.html#ui_locales" class="tsd-kind-icon">ui_<wbr>locales</a></li>
 						</ul>
 					</section>
@@ -3041,6 +3042,25 @@ img {
 						along with this scope</p>
 					</div>
 				</div>
+      </section>
+      <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-overwrite tsd-is-inherited">
+				<a name="screen_hint" class="tsd-anchor"></a>
+				<h3><span class="tsd-flag ts-flagOptional">Optional</span> screen_hint</h3>
+				<div class="tsd-signature tsd-kind-icon">screen_hint<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"login"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"signup"</span><span class="tsd-signature-symbol"></div>
+				<aside class="tsd-sources">
+					<p>Inherited from BaseLoginOptions.screen_hint</p>
+					<p>Overrides BaseLoginOptions.screen_hint</p>
+					<ul>
+						<li>Defined in node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts:48</li>
+					</ul>
+				</aside>
+				<div class="tsd-comment tsd-typography">
+					<div class="lead">
+            <p>The form to show when a user is redirected to the Auth0 Universal Login page.</p>
+            <li><code>&#39;login&#39;</code>: (default) shows the login form</li>
+						<li><code>&#39;singup&#39;</code>: shows the signup form</li>
+					</div>
+        </div>
 			</section>
 			<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-overwrite tsd-is-inherited">
 				<a name="ui_locales" class="tsd-anchor"></a>


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> https://auth0.github.io/auth0-react/interfaces/redirectloginoptions.html is missing the optional property screen_hint

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [n/a] The correct base branch is being used, if not `master`
