### PR TITLE
Remove unintential render after each getAccessToken* call

### DIFF
--- a/examples/cra-react-router/src/ProtectedRoute.tsx
+++ b/examples/cra-react-router/src/ProtectedRoute.tsx
@@ -7,10 +7,13 @@ export const ProtectedRoute = ({
   ...args
 }: React.PropsWithChildren<any>) => (
   <Route
-    component={withAuthenticationRequired(component, {
-      // If using a Hash Router, you need to pass the hash fragment as `returnTo`
-      // returnTo: () => window.location.hash.substr(1),
-    })}
+    render={(props) => {
+      let Component = withAuthenticationRequired(component, {
+        // If using a Hash Router, you need to pass the hash fragment as `returnTo`
+        // returnTo: () => window.location.hash.substr(1),
+      });
+      return <Component {...props} />;
+    }}
     {...args}
   />
 );

--- a/examples/gatsby-app/src/components/ProtectedRoute.js
+++ b/examples/gatsby-app/src/components/ProtectedRoute.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import { withAuthenticationRequired } from '@auth0/auth0-react';
-
-const PrivateRoute = ({ component: Component, ...rest }) => {
-  const PrivateComponent = withAuthenticationRequired(Component);
-  return <PrivateComponent {...rest} />;
-};
-
-export default PrivateRoute;

--- a/examples/gatsby-app/src/pages/index.js
+++ b/examples/gatsby-app/src/pages/index.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import { Router } from '@reach/router';
-import { useAuth0 } from '@auth0/auth0-react';
+import { useAuth0, withAuthenticationRequired } from '@auth0/auth0-react';
 import { Nav } from '../components/Nav';
-import ProtectedRoute from '../components/ProtectedRoute';
 import { Users } from '../components/Users';
 import { Loading } from '../components/Loading';
 import { Error } from '../components/Error';
+
+const ProtectedRoute = withAuthenticationRequired(Users);
 
 const IndexPage = () => {
   const { isLoading, error } = useAuth0();

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "jest --coverage",
     "prepack": "npm run test && npm run build",
     "docs": "typedoc --options typedoc.js src node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
-    "install:examples": "npm i --prefix=examples/cra-react-router --no-package-lock; npm i --prefix=examples/gatsby-app --no-package-lock; npm i --prefix=examples/nextjs-app --no-package-lock; npm ci --prefix=examples/users-api",
+    "install:examples": "npm i --prefix=examples/cra-react-router --no-package-lock && npm i --prefix=examples/gatsby-app --no-package-lock && npm i --prefix=examples/nextjs-app --no-package-lock && npm ci --prefix=examples/users-api",
     "start:cra": "npm start --prefix=examples/cra-react-router",
     "start:gatsby": "npm start --prefix=examples/gatsby-app",
     "start:nextjs": "npm run dev --prefix=examples/nextjs-app",
@@ -37,7 +37,7 @@
     "test:gatsby:watch": "start-server-and-test start:api 3001 start:gatsby 3000 cypress:open",
     "test:nextjs": "start-server-and-test start:api 3001 start:nextjs 3000 cypress:run",
     "test:nextjs:watch": "start-server-and-test start:api 3001 start:nextjs 3000 cypress:open",
-    "test:integration": "npm run test:cra; npm run test:gatsby; npm run test:nextjs",
+    "test:integration": "npm run test:cra && npm run test:gatsby && npm run test:nextjs",
     "cypress:run": "cypress run",
     "cypress:open": "cypress open",
     "codecov": "codecov"

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -260,6 +260,8 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
     [client]
   );
 
+  const userUpdatedAt = state.user?.updated_at;
+
   const getAccessTokenSilently = useCallback(
     async (opts?: GetTokenSilentlyOptions): Promise<string> => {
       let token;
@@ -269,10 +271,12 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
         throw tokenError(error);
       }
       const user = await client.getUser();
-      dispatch({ type: 'GET_TOKEN_COMPLETE', user });
+      if (user.updated_at !== userUpdatedAt) {
+        dispatch({ type: 'USER_UPDATED', user });
+      }
       return token;
     },
-    [client]
+    [client, userUpdatedAt]
   );
 
   const getAccessTokenWithPopup = useCallback(
@@ -287,10 +291,12 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
         throw tokenError(error);
       }
       const user = await client.getUser();
-      dispatch({ type: 'GET_TOKEN_COMPLETE', user });
+      if (user.updated_at !== userUpdatedAt) {
+        dispatch({ type: 'USER_UPDATED', user });
+      }
       return token;
     },
-    [client]
+    [client, userUpdatedAt]
   );
 
   const getIdTokenClaims = useCallback(

--- a/src/reducer.tsx
+++ b/src/reducer.tsx
@@ -3,7 +3,7 @@ import { AuthState, User } from './auth-state';
 type Action =
   | { type: 'LOGIN_POPUP_STARTED' }
   | {
-      type: 'INITIALISED' | 'LOGIN_POPUP_COMPLETE' | 'GET_TOKEN_COMPLETE';
+      type: 'INITIALISED' | 'LOGIN_POPUP_COMPLETE' | 'USER_UPDATED';
       user?: User;
     }
   | { type: 'LOGOUT' }
@@ -28,7 +28,7 @@ export const reducer = (state: AuthState, action: Action): AuthState => {
         isLoading: false,
         error: undefined,
       };
-    case 'GET_TOKEN_COMPLETE':
+    case 'USER_UPDATED':
       return {
         ...state,
         isAuthenticated: !!action.user,


### PR DESCRIPTION
### Description

- Fix issue where CI wasn't picking up failing Gatsby and CRA tests
- Any updates in the provider will trigger a new render of child components so only dispatch the user update when the `updated_at` date has changed (this should satisfy #135)
- Fix the Gatsby and CRA examples, `ProtectedRoute` shouldn't remount every time the app rerenders

### References

Fixes #155 

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
