### PR TITLE
Add link to info about storage options on cacheLocation

### DIFF
--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -84,6 +84,8 @@ export interface Auth0ProviderOptions {
   /**
    * The location to use when storing cache data. Valid values are `memory` or `localstorage`.
    * The default setting is `memory`.
+   *
+   * Read more about [changing storage options in the Auth0 docs](https://auth0.com/docs/libraries/auth0-single-page-app-sdk#change-storage-options)
    */
   cacheLocation?: CacheLocation;
   /**


### PR DESCRIPTION
### Description

Fuelled by [this issue on the React samples](https://github.com/auth0-samples/auth0-react-samples/pull/215), this PR adds more context to the `cacheLocation` property with a link off to read more about the storage options. This makes sense, as the docs also carry a warning about local storage that we're not otherwise relaying here.

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
