### PR TITLE
Update Types for LoginWithRedirect

### DIFF
--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -164,8 +164,8 @@ const toAuth0ClientOptions = (
  * @ignore
  */
 const toAuth0LoginRedirectOptions = (
-  opts?: Auth0RedirectLoginOptions
-): RedirectLoginOptions | undefined => {
+  opts?: RedirectLoginOptions
+): Auth0RedirectLoginOptions | undefined => {
   if (!opts) {
     return;
   }
@@ -229,7 +229,7 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
   }, [client, onRedirectCallback, skipRedirectCallback]);
 
   const loginWithRedirect = useCallback(
-    (opts?: Auth0RedirectLoginOptions): Promise<void> =>
+    (opts?: RedirectLoginOptions): Promise<void> =>
       client.loginWithRedirect(toAuth0LoginRedirectOptions(opts)),
     [client]
   );


### PR DESCRIPTION
The types, used internally, are configured incorrectly. This works fine because of the fact that the types are configured to allow any unknown property to be set.

Switching the types should not affect anyone using the SDK.