### PR TITLE
isLoading should default to true even when doing SSR

### DIFF
--- a/__tests__/ssr.test.tsx
+++ b/__tests__/ssr.test.tsx
@@ -1,21 +1,26 @@
 /**
  * @jest-environment node
  */
-import { renderHook } from '@testing-library/react-hooks';
-import { createWrapper } from './helpers';
-import { useAuth0 } from '../src';
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import { Auth0Provider, Auth0Context } from '../src';
 
 jest.unmock('@auth0/auth0-spa-js');
 
 describe('In a Node SSR environment', () => {
   it('auth state is initialised', async () => {
-    const wrapper = createWrapper();
-    const {
-      result: {
-        current: { isLoading, isAuthenticated, user, loginWithRedirect },
-      },
-    } = renderHook(useAuth0, { wrapper });
-    expect(isLoading).toBeFalsy();
+    let isLoading, isAuthenticated, user, loginWithRedirect;
+    ReactDOMServer.renderToString(
+      <Auth0Provider clientId="__client_id__" domain="__domain__">
+        <Auth0Context.Consumer>
+          {(value): JSX.Element => {
+            ({ isLoading, isAuthenticated, user, loginWithRedirect } = value);
+            return <div>App</div>;
+          }}
+        </Auth0Context.Consumer>
+      </Auth0Provider>
+    );
+    expect(isLoading).toBeTruthy();
     expect(isAuthenticated).toBeFalsy();
     expect(user).toBeUndefined();
     await expect(loginWithRedirect).rejects.toThrowError(

--- a/src/auth-state.tsx
+++ b/src/auth-state.tsx
@@ -15,6 +15,5 @@ export interface AuthState {
  */
 export const initialAuthState: AuthState = {
   isAuthenticated: false,
-  // In SSR mode the library will never check the session, so loading should be initialised as false
-  isLoading: typeof window !== 'undefined',
+  isLoading: true,
 };


### PR DESCRIPTION
### Description

I originally thought `isLoading` should initialize as `false` when doing SSR, the logic being that the SDK will never start loading during SSR so `isLoading` didn't make sense to be `true`

However, the output of SSR rendering is rendered on the client, to be hydrated, so a client will expect it to be initialised as `true`. If it's `false`, then immediately hydrated as `true` you get `Warning: Expected server HTML to contain a matching <div> in <div>.` because it's been rendered in a different state that the `ReactDom.hydrate` is expecting.

Whilst this will change initial rendering behaviour, it shouldn't break anyone - just remove the warning.

### References

fixes #182 

### Testing

I've changed the SSR tests to use `ReactDOMServer.renderToString` rather than `renderHook` because `renderHook` still expects to be called in a jsdom environment.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
