### PR TITLE
feat: Add popup option to `withAuthenticationRequired`

### DIFF
--- a/__tests__/with-authentication-required.test.tsx
+++ b/__tests__/with-authentication-required.test.tsx
@@ -131,4 +131,18 @@ describe('withAuthenticationRequired', () => {
       )
     );
   });
+
+  it('should use popup authentication when specified', async () => {
+    mockClient.getUser.mockResolvedValue(undefined);
+    const MyComponent = (): JSX.Element => <>Private</>;
+    const WrappedComponent = withAuthenticationRequired(MyComponent, {
+      popup: true,
+    });
+    render(
+      <Auth0Provider clientId="__test_client_id__" domain="__test_domain__">
+        <WrappedComponent />
+      </Auth0Provider>
+    );
+    await waitFor(() => expect(mockClient.loginWithPopup).toHaveBeenCalled());
+  });
 });

--- a/src/with-authentication-required.tsx
+++ b/src/with-authentication-required.tsx
@@ -60,6 +60,17 @@ export interface WithAuthenticationRequiredOptions {
    * This will be merged with the `returnTo` option used by the `onRedirectCallback` handler.
    */
   loginOptions?: RedirectLoginOptions;
+
+  /**
+   * ```js
+   * withAuthenticationRequired(Profile, {
+   *   popup: true
+   * })
+   * ```
+   *
+   *
+   */
+  popup?: boolean;
 }
 
 /**
@@ -75,11 +86,17 @@ const withAuthenticationRequired = <P extends object>(
   options: WithAuthenticationRequiredOptions = {}
 ): FC<P> => {
   return function WithAuthenticationRequired(props: P): JSX.Element {
-    const { isAuthenticated, isLoading, loginWithRedirect } = useAuth0();
+    const {
+      isAuthenticated,
+      isLoading,
+      loginWithRedirect,
+      loginWithPopup,
+    } = useAuth0();
     const {
       returnTo = defaultReturnTo,
       onRedirecting = defaultOnRedirecting,
       loginOptions = {},
+      popup = false,
     } = options;
 
     useEffect(() => {
@@ -93,13 +110,24 @@ const withAuthenticationRequired = <P extends object>(
           returnTo: typeof returnTo === 'function' ? returnTo() : returnTo,
         },
       };
+
+      const loginMethod = popup ? loginWithPopup : loginWithRedirect;
+
       (async (): Promise<void> => {
-        await loginWithRedirect(opts);
+        await loginMethod(opts);
       })();
-    }, [isLoading, isAuthenticated, loginWithRedirect, loginOptions, returnTo]);
+    }, [
+      isLoading,
+      isAuthenticated,
+      loginWithRedirect,
+      loginWithPopup,
+      loginOptions,
+      popup,
+      returnTo,
+    ]);
 
     return isAuthenticated ? <Component {...props} /> : onRedirecting();
   };
-}
+};
 
 export default withAuthenticationRequired;

--- a/src/with-authentication-required.tsx
+++ b/src/with-authentication-required.tsx
@@ -68,7 +68,7 @@ export interface WithAuthenticationRequiredOptions {
    * })
    * ```
    *
-   *
+   * Uses loginWithPopup when set to true.
    */
   popup?: boolean;
 }


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Gives users the option to Auth with a Popup in wrapped components. This is driven by the need for an app to function inside an iframe.

Added a `popup` option to `withAuthenticationRequired` option dictionary. It defaults to `false`. The login method is then chosen based on the value of `popup`.

### References

- Closes #166 

### Testing

Test by setting `popup` to `true` when wrapping a component.

Developed in TS on macOS 10.15.7 in Chrome 88

- [x] This change adds test coverage for new/changed/fixed functionality

Not entirely sure why my test isn't passing

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
