### PR TITLE
Fix buildAuthorizeUrl tests

### DIFF
--- a/__tests__/auth-provider.test.tsx
+++ b/__tests__/auth-provider.test.tsx
@@ -223,11 +223,12 @@ describe('Auth0Provider', () => {
     await waitForNextUpdate();
     expect(result.current.buildAuthorizeUrl).toBeInstanceOf(Function);
 
-    const authOptions = {
+    await result.current.buildAuthorizeUrl({
       redirectUri: '__redirect_uri__',
-    };
-    await result.current.buildAuthorizeUrl(authOptions);
-    expect(clientMock.buildAuthorizeUrl).toHaveBeenCalledWith(authOptions);
+    });
+    expect(clientMock.buildAuthorizeUrl).toHaveBeenCalledWith({
+      redirect_uri: '__redirect_uri__',
+    });
   });
 
   it('should call through to buildLogoutUrl method', async () => {


### PR DESCRIPTION
I merged a PR from a fork with a broken test - just fixing the build

`buildAuthorizeUrl` accepts `redirectUri` and calls the SPA JS client with `redirect_uri ` 