### PR TITLE
Add FAQ about redirecting to /

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -20,3 +20,26 @@ In this case Silent Authentication will not work because it relies on a hidden i
 ## 2. User is not logged in after successful sign in with redirect
 
 If after successfully logging in, your user returns to your SPA and is still not authenticated, do _not_ refresh the page - go to the Network tab on Chrome and confirm that the POST to `oauth/token` resulted in an error `401 Unauthorized`. If this is the case, your tenant is most likely misconfigured. Go to your **Application Properties** in your application's settings in the [Auth0 Dashboard](https://manage.auth0.com) and make sure that `Application Type` is set to `Single Page Application` and `Token Endpoint Authentication Method` is set to `None` (**Note:** there is a known issue with the Auth0 "Default App", if you are unable to set `Token Endpoint Authentication Method` to `None`, create a new Application of type `Single Page Application` or see the advice in [issues/93](https://github.com/auth0/auth0-react/issues/93#issuecomment-673431605))
+
+## 3. User is redirected to `/` after successful sign in with redirect
+
+By default, the SDK is configured to redirect the user back to the root of the application after succesfully exchanging the `code` for the corresponding token(s).
+
+This is what a typical default flow looks like:
+
+- Auth0Provider is configured with a specific redirectUrl (e.g. `http://localhost:4200/callback`).
+- User initiates login by calling `loginWithRedirect()`
+- User is redirected to Auth0, including a `redirectUri` (e.g. `http://localhost:3000/callback`)
+- After succesful authentication, the user is redirected back to the provided redirectUri, including a `code` and `state` query parameter (in this case `http://localhost:3000/callback?code={code}&state={state}`)
+- The configured `redirectUri` is only used to process `code` and `state` in order to retrieve an actual token.
+- The user is then redirected to `/`.
+
+However, if the user should not be redirected back to `/` in the very last step, but instead they should end up at a different URL, this can be configured by providing that information to `loginWithRedirect()`:
+
+```
+loginWithRedirect({
+  appState: { target: '/some-url' }
+});
+```
+
+By doing that, in the very last step the SDK will not redirect the user back to `/`, but to `/some-url` instead.


### PR DESCRIPTION
Multiple times have users shown to be confused about why they end up being redirected back to / after handling the callback URL.

e.g. https://community.auth0.com/t/redirect-uri-issue-after-successful-login-with-auth0-auth0-angular/58111

This PR adds a section to the FAQ about this so that users are made aware of this but we can also point people to the FAQ where needed.

This PR originates from our Angular SDK (See PR: https://github.com/auth0/auth0-angular/pull/127), but since we have the same FAQ and the newly added FAQ entry also counts for React, I decided to open a PR here as well.