### PR TITLE
Updates to user should not update memoized getAccessToken* methods

### DIFF
--- a/__tests__/auth-provider.test.tsx
+++ b/__tests__/auth-provider.test.tsx
@@ -434,6 +434,25 @@ describe('Auth0Provider', () => {
     expect(result.current.user).toBe(prevUser);
   });
 
+  it('should not update getAccessTokenSilently after auth state change', async () => {
+    clientMock.getTokenSilently.mockReturnThis();
+    clientMock.getUser.mockResolvedValue({ name: 'foo', updated_at: '1' });
+    const wrapper = createWrapper();
+    const { waitForNextUpdate, result } = renderHook(
+      () => useContext(Auth0Context),
+      { wrapper }
+    );
+    await waitForNextUpdate();
+    const memoized = result.current.getAccessTokenSilently;
+    expect(result.current.user.name).toEqual('foo');
+    clientMock.getUser.mockResolvedValue({ name: 'bar', updated_at: '2' });
+    await act(async () => {
+      await result.current.getAccessTokenSilently();
+    });
+    expect(result.current.user.name).toEqual('bar');
+    expect(result.current.getAccessTokenSilently).toBe(memoized);
+  });
+
   it('should handle not having a user while calling getAccessTokenSilently', async () => {
     const token = '__test_token__';
     clientMock.getTokenSilently.mockResolvedValue(token);

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -274,8 +274,6 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
     [client]
   );
 
-  const userUpdatedAt = state.user?.updated_at;
-
   const getAccessTokenSilently = useCallback(
     async (opts?: GetTokenSilentlyOptions): Promise<string> => {
       let token;
@@ -284,13 +282,13 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
       } catch (error) {
         throw tokenError(error);
       }
-      const user = await client.getUser();
-      if (user?.updated_at !== userUpdatedAt) {
-        dispatch({ type: 'USER_UPDATED', user });
-      }
+      dispatch({
+        type: 'GET_ACCESS_TOKEN_COMPLETE',
+        user: await client.getUser(),
+      });
       return token;
     },
-    [client, userUpdatedAt]
+    [client]
   );
 
   const getAccessTokenWithPopup = useCallback(
@@ -304,13 +302,13 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
       } catch (error) {
         throw tokenError(error);
       }
-      const user = await client.getUser();
-      if (user?.updated_at !== userUpdatedAt) {
-        dispatch({ type: 'USER_UPDATED', user });
-      }
+      dispatch({
+        type: 'GET_ACCESS_TOKEN_COMPLETE',
+        user: await client.getUser(),
+      });
       return token;
     },
-    [client, userUpdatedAt]
+    [client]
   );
 
   const getIdTokenClaims = useCallback(

--- a/src/reducer.tsx
+++ b/src/reducer.tsx
@@ -3,7 +3,10 @@ import { AuthState, User } from './auth-state';
 type Action =
   | { type: 'LOGIN_POPUP_STARTED' }
   | {
-      type: 'INITIALISED' | 'LOGIN_POPUP_COMPLETE' | 'USER_UPDATED';
+      type:
+        | 'INITIALISED'
+        | 'LOGIN_POPUP_COMPLETE'
+        | 'GET_ACCESS_TOKEN_COMPLETE';
       user?: User;
     }
   | { type: 'LOGOUT' }
@@ -28,7 +31,10 @@ export const reducer = (state: AuthState, action: Action): AuthState => {
         isLoading: false,
         error: undefined,
       };
-    case 'USER_UPDATED':
+    case 'GET_ACCESS_TOKEN_COMPLETE':
+      if (state.user?.updated_at === action.user?.updated_at) {
+        return state;
+      }
       return {
         ...state,
         isAuthenticated: !!action.user,


### PR DESCRIPTION
### Description

Updates to the `user` from the Authorization Server should not require updates to the `getAccessToken*` memoized methods. (Thanks for the suggestion @xepps)

### References

fixes #210 

### Testing

- add a side effect that depends on `getAccessTokenSilently`, eg `useEffect(() => console.log('changed'), [getAccessTokenSilently])`
- login
- make a change to your user (eg name) in the tenant dashboard
- call `getAccessTokenSilently({ ignoreCache: true })`
- anything rendering the user name should change, but the side effect should not be called

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
