### PR TITLE
Remove unneeded patch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,6 @@ jobs:
             - ~/.cache
       - run: npm run build
       - run: npm test
-      # TODO: remove when facebook/create-react-app#8845 is shipped
-      - run: sed -i '/process.env.CI/ s/isInteractive [|]*//' examples/cra-react-router/node_modules/react-scripts/scripts/start.js
       - run: npm run test:integration
       - run: npm run codecov
       - store_test_results:


### PR DESCRIPTION
Don't need to work around facebook/create-react-app#8845 anymore because the `create-react-app` example has a newer version of `react-scripts`