### PR TITLE
Skip integration tests on forked PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,12 @@ jobs:
       - restore_cache:
           key: dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}-{{ checksum "examples/cra-react-router/package.json" }}-{{ checksum "examples/gatsby-app/package.json" }}-{{ checksum "examples/nextjs-app/package.json" }}-{{ checksum "examples/users-api/package-lock.json" }}
       - run: npm ci
-      - run: npm run install:examples
+      - run:
+          name: npm run install:examples
+          command: |
+            if [ -z "$CIRCLE_PR_NUMBER" ]; then
+              npm run install:examples
+            fi
       - save_cache:
           key: dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}-{{ checksum "examples/cra-react-router/package.json" }}-{{ checksum "examples/gatsby-app/package.json" }}-{{ checksum "examples/nextjs-app/package.json" }}-{{ checksum "examples/users-api/package-lock.json" }}
           paths:
@@ -17,9 +22,12 @@ jobs:
             - ~/.cache
       - run: npm run build
       - run: npm test
-      # TODO: remove when facebook/create-react-app#8845 is shipped
-      - run: sed -i '/process.env.CI/ s/isInteractive [|]*//' examples/cra-react-router/node_modules/react-scripts/scripts/start.js
-      - run: npm run test:integration
+      - run:
+          name: npm run test:integration
+          command: |
+            if [ -z "$CIRCLE_PR_NUMBER" ]; then
+              npm run test:integration
+            fi
       - run: npm run codecov
       - store_test_results:
           path: test-results

--- a/examples/cra-react-router/package.json
+++ b/examples/cra-react-router/package.json
@@ -17,7 +17,7 @@
     "react": "file:../../node_modules/react",
     "react-dom": "file:../../node_modules/react-dom",
     "react-router-dom": "^5.2.0",
-    "react-scripts": "^3.4.1",
+    "react-scripts": "^4.0.3",
     "typescript": "^3.7.5"
   },
   "scripts": {

--- a/examples/cra-react-router/tsconfig.json
+++ b/examples/cra-react-router/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react"
+    "jsx": "react",
+    "noFallthroughCasesInSwitch": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
### Description

If we skip integration tests on forked PRs we can enable the build and run the unit tests on forked PRs

Bumped `react-scripts` so we can get rid of the patch for facebook/create-react-app#8845

### References

https://github.com/auth0/nextjs-auth0/pull/341
