### PR TITLE
Update auth state on fail

### DIFF
--- a/__tests__/auth-provider.test.tsx
+++ b/__tests__/auth-provider.test.tsx
@@ -434,6 +434,25 @@ describe('Auth0Provider', () => {
     expect(result.current.user).toBe(prevUser);
   });
 
+  it('should not update getAccessTokenSilently after auth state change', async () => {
+    clientMock.getTokenSilently.mockReturnThis();
+    clientMock.getUser.mockResolvedValue({ name: 'foo', updated_at: '1' });
+    const wrapper = createWrapper();
+    const { waitForNextUpdate, result } = renderHook(
+      () => useContext(Auth0Context),
+      { wrapper }
+    );
+    await waitForNextUpdate();
+    const memoized = result.current.getAccessTokenSilently;
+    expect(result.current.user.name).toEqual('foo');
+    clientMock.getUser.mockResolvedValue({ name: 'bar', updated_at: '2' });
+    await act(async () => {
+      await result.current.getAccessTokenSilently();
+    });
+    expect(result.current.user.name).toEqual('bar');
+    expect(result.current.getAccessTokenSilently).toBe(memoized);
+  });
+
   it('should handle not having a user while calling getAccessTokenSilently', async () => {
     const token = '__test_token__';
     clientMock.getTokenSilently.mockResolvedValue(token);

--- a/__tests__/auth-provider.test.tsx
+++ b/__tests__/auth-provider.test.tsx
@@ -416,6 +416,27 @@ describe('Auth0Provider', () => {
     expect(result.current.user.name).toEqual('bar');
   });
 
+  it('should update auth state after getAccessTokenSilently fails', async () => {
+    clientMock.getTokenSilently.mockReturnThis();
+    clientMock.getUser.mockResolvedValue({ name: 'foo', updated_at: '1' });
+    const wrapper = createWrapper();
+    const { waitForNextUpdate, result } = renderHook(
+      () => useContext(Auth0Context),
+      { wrapper }
+    );
+    await waitForNextUpdate();
+
+    expect(result.current.isAuthenticated).toBeTruthy();
+    clientMock.getTokenSilently.mockRejectedValue({ error: 'login_required' });
+    clientMock.getUser.mockResolvedValue(undefined);
+    await act(async () => {
+      await expect(() =>
+        result.current.getAccessTokenSilently()
+      ).rejects.toThrowError('login_required');
+    });
+    expect(result.current.isAuthenticated).toBeFalsy();
+  });
+
   it('should ignore same user after getAccessTokenSilently', async () => {
     clientMock.getTokenSilently.mockReturnThis();
     clientMock.getUser.mockResolvedValue({ name: 'foo', updated_at: '1' });
@@ -512,6 +533,27 @@ describe('Auth0Provider', () => {
       await result.current.getAccessTokenWithPopup();
     });
     expect(result.current.user).not.toBe(prevUser);
+  });
+
+  it('should update auth state after getAccessTokenWithPopup fails', async () => {
+    clientMock.getTokenSilently.mockReturnThis();
+    clientMock.getUser.mockResolvedValue({ name: 'foo', updated_at: '1' });
+    const wrapper = createWrapper();
+    const { waitForNextUpdate, result } = renderHook(
+      () => useContext(Auth0Context),
+      { wrapper }
+    );
+    await waitForNextUpdate();
+
+    expect(result.current.isAuthenticated).toBeTruthy();
+    clientMock.getTokenWithPopup.mockRejectedValue({ error: 'login_required' });
+    clientMock.getUser.mockResolvedValue(undefined);
+    await act(async () => {
+      await expect(() =>
+        result.current.getAccessTokenWithPopup()
+      ).rejects.toThrowError('login_required');
+    });
+    expect(result.current.isAuthenticated).toBeFalsy();
   });
 
   it('should ignore same auth state after getAccessTokenWithPopup', async () => {

--- a/__tests__/auth-provider.test.tsx
+++ b/__tests__/auth-provider.test.tsx
@@ -455,25 +455,6 @@ describe('Auth0Provider', () => {
     expect(result.current.user).toBe(prevUser);
   });
 
-  it('should not update getAccessTokenSilently after auth state change', async () => {
-    clientMock.getTokenSilently.mockReturnThis();
-    clientMock.getUser.mockResolvedValue({ name: 'foo', updated_at: '1' });
-    const wrapper = createWrapper();
-    const { waitForNextUpdate, result } = renderHook(
-      () => useContext(Auth0Context),
-      { wrapper }
-    );
-    await waitForNextUpdate();
-    const memoized = result.current.getAccessTokenSilently;
-    expect(result.current.user.name).toEqual('foo');
-    clientMock.getUser.mockResolvedValue({ name: 'bar', updated_at: '2' });
-    await act(async () => {
-      await result.current.getAccessTokenSilently();
-    });
-    expect(result.current.user.name).toEqual('bar');
-    expect(result.current.getAccessTokenSilently).toBe(memoized);
-  });
-
   it('should handle not having a user while calling getAccessTokenSilently', async () => {
     const token = '__test_token__';
     clientMock.getTokenSilently.mockResolvedValue(token);

--- a/__tests__/auth-provider.test.tsx
+++ b/__tests__/auth-provider.test.tsx
@@ -378,9 +378,11 @@ describe('Auth0Provider', () => {
       { wrapper }
     );
     await waitForNextUpdate();
-    expect(result.current.getAccessTokenSilently).rejects.toThrowError(
-      'Get access token failed'
-    );
+    await act(async () => {
+      await expect(result.current.getAccessTokenSilently).rejects.toThrowError(
+        'Get access token failed'
+      );
+    });
   });
 
   it('should call getAccessTokenSilently in the scope of the Auth0 client', async () => {
@@ -546,7 +548,9 @@ describe('Auth0Provider', () => {
     await waitForNextUpdate();
 
     expect(result.current.isAuthenticated).toBeTruthy();
-    clientMock.getTokenWithPopup.mockRejectedValue({ error: 'login_required' });
+    clientMock.getTokenWithPopup.mockRejectedValueOnce({
+      error: 'login_required',
+    });
     clientMock.getUser.mockResolvedValue(undefined);
     await act(async () => {
       await expect(() =>
@@ -582,9 +586,11 @@ describe('Auth0Provider', () => {
       { wrapper }
     );
     await waitForNextUpdate();
-    expect(result.current.getAccessTokenWithPopup).rejects.toThrowError(
-      'Get access token failed'
-    );
+    await act(async () => {
+      await expect(result.current.getAccessTokenWithPopup).rejects.toThrowError(
+        'Get access token failed'
+      );
+    });
   });
 
   it('should handle not having a user while calling getAccessTokenWithPopup', async () => {

--- a/__tests__/auth-provider.test.tsx
+++ b/__tests__/auth-provider.test.tsx
@@ -455,6 +455,25 @@ describe('Auth0Provider', () => {
     expect(result.current.user).toBe(prevUser);
   });
 
+  it('should not update getAccessTokenSilently after auth state change', async () => {
+    clientMock.getTokenSilently.mockReturnThis();
+    clientMock.getUser.mockResolvedValue({ name: 'foo', updated_at: '1' });
+    const wrapper = createWrapper();
+    const { waitForNextUpdate, result } = renderHook(
+      () => useContext(Auth0Context),
+      { wrapper }
+    );
+    await waitForNextUpdate();
+    const memoized = result.current.getAccessTokenSilently;
+    expect(result.current.user.name).toEqual('foo');
+    clientMock.getUser.mockResolvedValue({ name: 'bar', updated_at: '2' });
+    await act(async () => {
+      await result.current.getAccessTokenSilently();
+    });
+    expect(result.current.user.name).toEqual('bar');
+    expect(result.current.getAccessTokenSilently).toBe(memoized);
+  });
+
   it('should handle not having a user while calling getAccessTokenSilently', async () => {
     const token = '__test_token__';
     clientMock.getTokenSilently.mockResolvedValue(token);

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -274,8 +274,6 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
     [client]
   );
 
-  const userUpdatedAt = state.user?.updated_at;
-
   const getAccessTokenSilently = useCallback(
     async (opts?: GetTokenSilentlyOptions): Promise<string> => {
       let token;
@@ -284,13 +282,13 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
       } catch (error) {
         throw tokenError(error);
       }
-      const user = await client.getUser();
-      if (user?.updated_at !== userUpdatedAt) {
-        dispatch({ type: 'USER_UPDATED', user });
-      }
+      dispatch({
+        type: 'GET_ACCESS_TOKEN_COMPLETE',
+        user: await client.getUser(),
+      });
       return token;
     },
-    [client, userUpdatedAt]
+    [client]
   );
 
   const getAccessTokenWithPopup = useCallback(
@@ -304,13 +302,13 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
       } catch (error) {
         throw tokenError(error);
       }
-      const user = await client.getUser();
-      if (user?.updated_at !== userUpdatedAt) {
-        dispatch({ type: 'USER_UPDATED', user });
-      }
+      dispatch({
+        type: 'GET_ACCESS_TOKEN_COMPLETE',
+        user: await client.getUser(),
+      });
       return token;
     },
-    [client, userUpdatedAt]
+    [client]
   );
 
   const getIdTokenClaims = useCallback(

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -281,11 +281,12 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
         token = await client.getTokenSilently(opts);
       } catch (error) {
         throw tokenError(error);
+      } finally {
+        dispatch({
+          type: 'GET_ACCESS_TOKEN_COMPLETE',
+          user: await client.getUser(),
+        });
       }
-      dispatch({
-        type: 'GET_ACCESS_TOKEN_COMPLETE',
-        user: await client.getUser(),
-      });
       return token;
     },
     [client]
@@ -301,11 +302,12 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
         token = await client.getTokenWithPopup(opts, config);
       } catch (error) {
         throw tokenError(error);
+      } finally {
+        dispatch({
+          type: 'GET_ACCESS_TOKEN_COMPLETE',
+          user: await client.getUser(),
+        });
       }
-      dispatch({
-        type: 'GET_ACCESS_TOKEN_COMPLETE',
-        user: await client.getUser(),
-      });
       return token;
     },
     [client]

--- a/src/reducer.tsx
+++ b/src/reducer.tsx
@@ -3,7 +3,10 @@ import { AuthState, User } from './auth-state';
 type Action =
   | { type: 'LOGIN_POPUP_STARTED' }
   | {
-      type: 'INITIALISED' | 'LOGIN_POPUP_COMPLETE' | 'USER_UPDATED';
+      type:
+        | 'INITIALISED'
+        | 'LOGIN_POPUP_COMPLETE'
+        | 'GET_ACCESS_TOKEN_COMPLETE';
       user?: User;
     }
   | { type: 'LOGOUT' }
@@ -28,7 +31,10 @@ export const reducer = (state: AuthState, action: Action): AuthState => {
         isLoading: false,
         error: undefined,
       };
-    case 'USER_UPDATED':
+    case 'GET_ACCESS_TOKEN_COMPLETE':
+      if (state.user?.updated_at === action.user?.updated_at) {
+        return state;
+      }
       return {
         ...state,
         isAuthenticated: !!action.user,


### PR DESCRIPTION
### Description

We should attempt to update the auth state after `getAccessToken*` methods fail, to handle the use case where the user may have been logged out in another tab.

### References

fixes: #218 

### Testing

- Add the `ignoreCache: true` option `getAccessTokenSilently` in the [playground](https://github.com/auth0/auth0-react/blob/master/static/index.html#L55)
- Run the playground `npm start` and visit http://localhost:3000
- Login to the app
- Open another tab and visit http://localhost:3000
- Both tabs should show the user as logged in
- Logout of the second tab
- Click `Get access token` in the first tab
- Both tabs should show the user as logged out

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] ~~The correct base branch is being used, if not master~~ (Will update the base when #213 is merged)
