### PR TITLE
[SDK-2522] Check for state along with error param

### DIFF
--- a/__tests__/auth-provider.test.tsx
+++ b/__tests__/auth-provider.test.tsx
@@ -155,7 +155,11 @@ describe('Auth0Provider', () => {
   });
 
   it('should handle redirect callback errors', async () => {
-    window.history.pushState({}, document.title, '/?error=__test_error__');
+    window.history.pushState(
+      {},
+      document.title,
+      '/?error=__test_error__&state=__test_state__'
+    );
     clientMock.handleRedirectCallback.mockRejectedValue(
       new Error('__test_error__')
     );

--- a/__tests__/utils.test.tsx
+++ b/__tests__/utils.test.tsx
@@ -17,9 +17,18 @@ describe('utils hasAuthParams', () => {
     ].forEach((search) => expect(hasAuthParams(search)).toBeTruthy());
   });
 
-  it('should recognise the error param', async () => {
+  it('should recognise the error and state param', async () => {
+    [
+      '?error=1&state=2',
+      '?foo=1&state=2&error=3',
+      '?error=1&foo=2&state=3',
+      '?state=1&error=2&foo=3',
+    ].forEach((search) => expect(hasAuthParams(search)).toBeTruthy());
+  });
+
+  it('should ignore the error param without state param', async () => {
     ['?error=1', '?foo=1&error=2', '?error=1&foo=2'].forEach((search) =>
-      expect(hasAuthParams(search)).toBeTruthy()
+      expect(hasAuthParams(search)).toBeFalsy()
     );
   });
 

--- a/examples/cra-react-router/src/Nav.tsx
+++ b/examples/cra-react-router/src/Nav.tsx
@@ -37,7 +37,7 @@ export function Nav() {
 
       {isAuthenticated ? (
         <div>
-          <span id="hello">Hello, {user.name}!</span>{' '}
+          <span id="hello">Hello, {user?.name}!</span>{' '}
           <button
             className="btn btn-outline-secondary"
             id="logout"

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -5,8 +5,8 @@ const STATE_RE = /[?&]state=[^&]+/;
 const ERROR_RE = /[?&]error=[^&]+/;
 
 export const hasAuthParams = (searchParams = window.location.search): boolean =>
-  (CODE_RE.test(searchParams) && STATE_RE.test(searchParams)) ||
-  ERROR_RE.test(searchParams);
+  (CODE_RE.test(searchParams) || ERROR_RE.test(searchParams)) &&
+  STATE_RE.test(searchParams);
 
 const normalizeErrorFn = (fallbackMessage: string) => (
   error: Error | { error: string; error_description?: string } | ProgressEvent


### PR DESCRIPTION
PKCE will always provide a `state` when it provides an `error` param in the callback, so we can check for that to prevent the `error` param clashing with other uses of the `error` param.

This matches `auth0-angular` https://github.com/auth0/auth0-angular/blob/master/projects/auth0-angular/src/lib/auth.service.ts#L317-L318

fixes: #225 