### PR TITLE
[SDK-2541] Expose handleRedirectCallback from auth0-spa-js

### DIFF
--- a/src/auth0-context.tsx
+++ b/src/auth0-context.tsx
@@ -9,6 +9,7 @@ import {
   PopupLoginOptions,
   PopupConfigOptions,
   RedirectLoginOptions as Auth0RedirectLoginOptions,
+  RedirectLoginResult,
 } from '@auth0/auth0-spa-js';
 import { createContext } from 'react';
 import { AuthState, initialAuthState, User } from './auth-state';
@@ -157,6 +158,16 @@ export interface Auth0ContextInterface<TUser extends User = User>
    * @param options
    */
   buildLogoutUrl: (options?: LogoutUrlOptions) => string;
+
+  /**
+   * After the browser redirects back to the callback page,
+   * call `handleRedirectCallback` to handle success and error
+   * responses from Auth0. If the response is successful, results
+   * will be valid according to their expiration times.
+   *
+   * @param url The URL to that should be used to retrieve the `state` and `code` values. Defaults to `window.location.href` if not given.
+   */
+  handleRedirectCallback: (url?: string) => Promise<RedirectLoginResult>;
 }
 
 /**
@@ -179,6 +190,7 @@ const initialContext = {
   loginWithRedirect: stub,
   loginWithPopup: stub,
   logout: stub,
+  handleRedirectCallback: stub,
 };
 
 /**

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -12,6 +12,7 @@ import {
   GetTokenWithPopupOptions,
   GetTokenSilentlyOptions,
   GetIdTokenClaimsOptions,
+  RedirectLoginResult,
 } from '@auth0/auth0-spa-js';
 import Auth0Context, { RedirectLoginOptions } from './auth0-context';
 import { hasAuthParams, loginError, tokenError } from './utils';
@@ -330,6 +331,22 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
     [client]
   );
 
+  const handleRedirectCallback = useCallback(
+    async (url?: string): Promise<RedirectLoginResult> => {
+      try {
+        return await client.handleRedirectCallback(url);
+      } catch (error) {
+        throw tokenError(error);
+      } finally {
+        dispatch({
+          type: 'HANDLE_REDIRECT_COMPLETE',
+          user: await client.getUser(),
+        });
+      }
+    },
+    [client]
+  );
+
   return (
     <Auth0Context.Provider
       value={{
@@ -342,6 +359,7 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
         loginWithRedirect,
         loginWithPopup,
         logout,
+        handleRedirectCallback,
       }}
     >
       {children}

--- a/src/reducer.tsx
+++ b/src/reducer.tsx
@@ -6,7 +6,8 @@ type Action =
       type:
         | 'INITIALISED'
         | 'LOGIN_POPUP_COMPLETE'
-        | 'GET_ACCESS_TOKEN_COMPLETE';
+        | 'GET_ACCESS_TOKEN_COMPLETE'
+        | 'HANDLE_REDIRECT_COMPLETE';
       user?: User;
     }
   | { type: 'LOGOUT' }
@@ -31,6 +32,7 @@ export const reducer = (state: AuthState, action: Action): AuthState => {
         isLoading: false,
         error: undefined,
       };
+    case 'HANDLE_REDIRECT_COMPLETE':
     case 'GET_ACCESS_TOKEN_COMPLETE':
       if (state.user?.updated_at === action.user?.updated_at) {
         return state;


### PR DESCRIPTION
This PR exposes the `handleRedirectCallback` function from `auth0-spa-js`,
which has been abstracted away until now. Exposing this enables a use case for
hybrid mobile (Capacitor, Cordova, etc) apps to be able to work end-to-end.

fixes #222 
