### PR TITLE
add getIdToken to Auth0Context

### DIFF
--- a/__mocks__/@auth0/auth0-spa-js.tsx
+++ b/__mocks__/@auth0/auth0-spa-js.tsx
@@ -6,6 +6,7 @@ const getTokenSilently = jest.fn();
 const getTokenWithPopup = jest.fn();
 const getUser = jest.fn();
 const getIdTokenClaims = jest.fn();
+const getIdToken = jest.fn();
 const isAuthenticated = jest.fn(() => false);
 const loginWithPopup = jest.fn();
 const loginWithRedirect = jest.fn();
@@ -21,6 +22,7 @@ export const Auth0Client = jest.fn(() => {
     getTokenWithPopup,
     getUser,
     getIdTokenClaims,
+    getIdToken,
     isAuthenticated,
     loginWithPopup,
     loginWithRedirect,

--- a/__tests__/auth-provider.test.tsx
+++ b/__tests__/auth-provider.test.tsx
@@ -682,6 +682,32 @@ describe('Auth0Provider', () => {
     expect(result.current.getIdTokenClaims).toBe(memoized);
   });
 
+  it('should provide a getIdToken method', async () => {
+    clientMock.getIdToken.mockResolvedValue('__test_id_token__');
+    const wrapper = createWrapper();
+    const { waitForNextUpdate, result } = renderHook(
+      () => useContext(Auth0Context),
+      { wrapper }
+    );
+    await waitForNextUpdate();
+    expect(result.current.getIdToken).toBeInstanceOf(Function);
+    const claims = await result.current.getIdToken();
+    expect(clientMock.getIdToken).toHaveBeenCalled();
+    expect(claims).toStrictEqual('__test_id_token__');
+  });
+
+  it('should memoize the getIdToken method', async () => {
+    const wrapper = createWrapper();
+    const { waitForNextUpdate, result, rerender } = renderHook(
+      () => useContext(Auth0Context),
+      { wrapper }
+    );
+    await waitForNextUpdate();
+    const memoized = result.current.getIdToken;
+    rerender();
+    expect(result.current.getIdToken).toBe(memoized);
+  });
+
   it('should provide a handleRedirectCallback method', async () => {
     clientMock.handleRedirectCallback.mockResolvedValue({
       appState: { redirectUri: '/' },

--- a/cypress/integration/smoke-bs.test.ts
+++ b/cypress/integration/smoke-bs.test.ts
@@ -18,7 +18,7 @@ const login = (): void => {
   return loginToNodeOidc();
 };
 
-const fixCookies = () => {
+const fixCookies = (): void => {
   // Temporary fix for https://github.com/cypress-io/cypress/issues/6375
   if (Cypress.isBrowser('firefox')) {
     cy.getCookies({ log: false }).then((cookies) =>

--- a/src/auth0-context.tsx
+++ b/src/auth0-context.tsx
@@ -96,6 +96,15 @@ export interface Auth0ContextInterface<TUser extends User = User>
 
   /**
    * ```js
+   * const claims = await getIdToken();
+   * ```
+   *
+   * Returns the raw id_token if available.
+   */
+  getIdToken: (options?: GetIdTokenClaimsOptions) => Promise<string>;
+
+  /**
+   * ```js
    * await loginWithRedirect(options);
    * ```
    *
@@ -188,6 +197,7 @@ const initialContext = {
   getAccessTokenSilently: stub,
   getAccessTokenWithPopup: stub,
   getIdTokenClaims: stub,
+  getIdToken: stub,
   loginWithRedirect: stub,
   loginWithPopup: stub,
   logout: stub,

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -243,7 +243,7 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
         const user = await client.getUser();
         dispatch({ type: 'INITIALISED', user });
       } catch (error) {
-        dispatch({ type: 'ERROR', error: loginError(error) });
+        dispatch({ type: 'ERROR', error: loginError(error as Error) });
       }
     })();
   }, [client, onRedirectCallback, skipRedirectCallback]);
@@ -274,7 +274,7 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
       try {
         await client.loginWithPopup(options, config);
       } catch (error) {
-        dispatch({ type: 'ERROR', error: loginError(error) });
+        dispatch({ type: 'ERROR', error: loginError(error as Error) });
         return;
       }
       const user = await client.getUser();
@@ -303,7 +303,7 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
       try {
         token = await client.getTokenSilently(opts);
       } catch (error) {
-        throw tokenError(error);
+        throw tokenError(error as Error);
       } finally {
         dispatch({
           type: 'GET_ACCESS_TOKEN_COMPLETE',
@@ -324,7 +324,7 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
       try {
         token = await client.getTokenWithPopup(opts, config);
       } catch (error) {
-        throw tokenError(error);
+        throw tokenError(error as Error);
       } finally {
         dispatch({
           type: 'GET_ACCESS_TOKEN_COMPLETE',
@@ -342,12 +342,18 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
     [client]
   );
 
+  const getIdToken = useCallback(
+    (opts?: GetIdTokenClaimsOptions): Promise<string> =>
+      client.getIdToken(opts),
+    [client]
+  );
+
   const handleRedirectCallback = useCallback(
     async (url?: string): Promise<RedirectLoginResult> => {
       try {
         return await client.handleRedirectCallback(url);
       } catch (error) {
-        throw tokenError(error);
+        throw tokenError(error as Error);
       } finally {
         dispatch({
           type: 'HANDLE_REDIRECT_COMPLETE',
@@ -367,6 +373,7 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
         getAccessTokenSilently,
         getAccessTokenWithPopup,
         getIdTokenClaims,
+        getIdToken,
         loginWithRedirect,
         loginWithPopup,
         logout,

--- a/src/use-auth0.tsx
+++ b/src/use-auth0.tsx
@@ -14,6 +14,7 @@ import Auth0Context, { Auth0ContextInterface } from './auth0-context';
  *   getAccessTokenSilently,
  *   getAccessTokenWithPopup,
  *   getIdTokenClaims,
+ *   getIdToken,
  *   loginWithRedirect,
  *   loginWithPopup,
  *   logout,

--- a/static/index.html
+++ b/static/index.html
@@ -45,6 +45,7 @@
           isAuthenticated,
           isLoading,
           getIdTokenClaims,
+          getIdToken,
           getAccessTokenSilently,
           getAccessTokenWithPopup,
           loginWithRedirect,
@@ -52,6 +53,7 @@
           logout,
         } = useAuth0();
         const [token, setToken] = useState(null);
+        const [rawToken, setRawToken] = useState(null);
         const [claims, setClaims] = useState(null);
 
         const changeToAuth0 = () => {
@@ -94,10 +96,14 @@
             <button onClick={async () => setClaims(await getIdTokenClaims())}>
               Get id_token claims
             </button>
+            <button onClick={async () => setRawToken(await getIdToken())}>
+              Get raw id_token
+            </button>
             {token && <pre>access_token: {token}</pre>}
             {claims && (
               <pre>id_token_claims: {JSON.stringify(claims, null, 2)}</pre>
             )}
+            {rawToken && <pre>id_token: {rawToken}</pre>}
           </div>
         ) : (
           <div>


### PR DESCRIPTION
Auth0-issued id_tokens are useful in their original form & should be easy to get to.

This PR corresponds to and depends upon pending PR793 in @auth0/auth0-spa-js, as it exposes a new method of same name in Auth0Client object underlying Auth0 Context.

Description
Added a method to make it as straightforward to get the id_token field from the cache as it is to get the claims decoded from it.

References
https://github.com/auth0/auth0-react/issues/262
https://github.com/auth0/auth0-spa-js/pull/793

Testing
[√] This change adds test coverage for new/changed/fixed functionality
tests passed using node v14.15.0, jest@26.6.3
it was necessary to update tsconfig.json to accept es2015 and dom syntax/symbols

Checklist
[√ via docblock] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
[√ npm build test] All active GitHub checks for tests, formatting, and security are passing
[√] The correct base branch is being used, if not master
