### PR TITLE
External client

### DIFF
--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -28,10 +28,7 @@ export type AppState = {
   [key: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 };
 
-/**
- * The main configuration to instantiate the `Auth0Provider`.
- */
-export interface Auth0ProviderOptions {
+export interface Auth0ProviderOptionsBase {
   /**
    * The child nodes your Provider has wrapped
    */
@@ -56,6 +53,12 @@ export interface Auth0ProviderOptions {
    * ```
    */
   skipRedirectCallback?: boolean;
+}
+
+/**
+ * The main configuration to instantiate the `Auth0Provider`.
+ */
+export interface Auth0ProviderOptions extends Auth0ProviderOptionsBase {
   /**
    * Your Auth0 account domain such as `'example.auth0.com'`,
    * `'example.eu.auth0.com'` or , `'example.mycompany.com'`
@@ -156,6 +159,17 @@ export interface Auth0ProviderOptions {
 }
 
 /**
+ * Alternative configuration to instantiate the `Auth0Provider`.
+ */
+export interface Auth0ProviderOptionsWithClient
+  extends Auth0ProviderOptionsBase {
+  /**
+   * Existing Auth0Client to reuse.
+   */
+  client: Auth0Client;
+}
+
+/**
  * Replaced by the package version at build time.
  * @ignore
  */
@@ -219,15 +233,18 @@ const defaultOnRedirectCallback = (appState?: AppState): void => {
  *
  * Provides the Auth0Context to its child components.
  */
-const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
+const Auth0Provider = (
+  opts: Auth0ProviderOptions | Auth0ProviderOptionsWithClient
+): JSX.Element => {
   const {
     children,
     skipRedirectCallback,
     onRedirectCallback = defaultOnRedirectCallback,
-    ...clientOpts
   } = opts;
-  const [client] = useState(
-    () => new Auth0Client(toAuth0ClientOptions(clientOpts))
+  const [client] = useState(() =>
+    opts.client
+      ? opts.client
+      : new Auth0Client(toAuth0ClientOptions(opts as Auth0ProviderOptions))
   );
   const [state, dispatch] = useReducer(reducer, initialAuthState);
 

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -53,6 +53,14 @@ export interface Auth0ProviderOptionsBase {
    * ```
    */
   skipRedirectCallback?: boolean;
+  /**
+   * The default URL where Auth0 will redirect your browser to with
+   * the authentication result. It must be whitelisted in
+   * the "Allowed Callback URLs" field in your Auth0 Application's
+   * settings. If not provided here, it should be provided in the other
+   * methods that provide authentication.
+   */
+  redirectUri?: string;
 }
 
 /**
@@ -73,14 +81,6 @@ export interface Auth0ProviderOptions extends Auth0ProviderOptionsBase {
    * The Client ID found on your Application settings page
    */
   clientId: string;
-  /**
-   * The default URL where Auth0 will redirect your browser to with
-   * the authentication result. It must be whitelisted in
-   * the "Allowed Callback URLs" field in your Auth0 Application's
-   * settings. If not provided here, it should be provided in the other
-   * methods that provide authentication.
-   */
-  redirectUri?: string;
   /**
    * The value in seconds used to account for clock skew in JWT expirations.
    * Typically, this value is no more than a minute or two at maximum.

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -58,14 +58,6 @@ export interface Auth0ProviderOptionsBase {
 export interface Auth0ProviderOptionsWithoutClient
   extends Auth0ProviderOptionsBase {
   /**
-   * The default URL where Auth0 will redirect your browser to with
-   * the authentication result. It must be whitelisted in
-   * the "Allowed Callback URLs" field in your Auth0 Application's
-   * settings. If not provided here, it should be provided in the other
-   * methods that provide authentication.
-   */
-  redirectUri?: string;
-  /**
    * Your Auth0 account domain such as `'example.auth0.com'`,
    * `'example.eu.auth0.com'` or , `'example.mycompany.com'`
    * (when using [custom domains](https://auth0.com/docs/custom-domains))
@@ -79,6 +71,14 @@ export interface Auth0ProviderOptionsWithoutClient
    * The Client ID found on your Application settings page
    */
   clientId: string;
+  /**
+   * The default URL where Auth0 will redirect your browser to with
+   * the authentication result. It must be whitelisted in
+   * the "Allowed Callback URLs" field in your Auth0 Application's
+   * settings. If not provided here, it should be provided in the other
+   * methods that provide authentication.
+   */
+  redirectUri?: string;
   /**
    * The value in seconds used to account for clock skew in JWT expirations.
    * Typically, this value is no more than a minute or two at maximum.

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -53,6 +53,10 @@ export interface Auth0ProviderOptionsBase {
    * ```
    */
   skipRedirectCallback?: boolean;
+}
+
+export interface Auth0ProviderOptionsWithoutClient
+  extends Auth0ProviderOptionsBase {
   /**
    * The default URL where Auth0 will redirect your browser to with
    * the authentication result. It must be whitelisted in
@@ -61,12 +65,6 @@ export interface Auth0ProviderOptionsBase {
    * methods that provide authentication.
    */
   redirectUri?: string;
-}
-
-/**
- * The main configuration to instantiate the `Auth0Provider`.
- */
-export interface Auth0ProviderOptions extends Auth0ProviderOptionsBase {
   /**
    * Your Auth0 account domain such as `'example.auth0.com'`,
    * `'example.eu.auth0.com'` or , `'example.mycompany.com'`
@@ -158,9 +156,6 @@ export interface Auth0ProviderOptions extends Auth0ProviderOptionsBase {
   [key: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
-/**
- * Alternative configuration to instantiate the `Auth0Provider`.
- */
 export interface Auth0ProviderOptionsWithClient
   extends Auth0ProviderOptionsBase {
   /**
@@ -168,6 +163,13 @@ export interface Auth0ProviderOptionsWithClient
    */
   client: Auth0Client;
 }
+
+/**
+ * The main configuration to instantiate the `Auth0Provider`.
+ */
+export type Auth0ProviderOptions =
+  | Auth0ProviderOptionsWithoutClient
+  | Auth0ProviderOptionsWithClient;
 
 /**
  * Replaced by the package version at build time.
@@ -179,7 +181,7 @@ declare const __VERSION__: string;
  * @ignore
  */
 const toAuth0ClientOptions = (
-  opts: Auth0ProviderOptions
+  opts: Auth0ProviderOptionsWithoutClient
 ): Auth0ClientOptions => {
   const { clientId, redirectUri, maxAge, ...validOpts } = opts;
   return {
@@ -233,9 +235,7 @@ const defaultOnRedirectCallback = (appState?: AppState): void => {
  *
  * Provides the Auth0Context to its child components.
  */
-const Auth0Provider = (
-  opts: Auth0ProviderOptions | Auth0ProviderOptionsWithClient
-): JSX.Element => {
+const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
   const {
     children,
     skipRedirectCallback,
@@ -244,7 +244,9 @@ const Auth0Provider = (
   const [client] = useState(() =>
     opts.client
       ? opts.client
-      : new Auth0Client(toAuth0ClientOptions(opts as Auth0ProviderOptions))
+      : new Auth0Client(
+          toAuth0ClientOptions(opts as Auth0ProviderOptionsWithoutClient)
+        )
   );
   const [state, dispatch] = useReducer(reducer, initialAuthState);
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Both React and Angular dedicated library use generic auth0 spa client underneeth. For some reasone however non of the libraries allow to reuse already existing client, only allowing to create one through the wrapper. That brings problems if (for any reason) cosumer decides to do depend on generic auth0 client (the same way that libraries do).

Example of such requirement would be any microfrontend (eg. singleSPA), where multiple micro apps are writen using different frameworks (angular + react, vanilla + react). Sharing one auth0 instance allows micro apps to be configuration agnostic. It also helps to avoid scenario where multiple generic client are instantiated in one 'window'. 

### Testing

<Auth0Provider clientId="ABCD" domain="example.com">
//...
</Auth0Provider>;


and

const auth0client = ...//create client using @auth0/auth0-spa-js

<Auth0Provider client="auth0client">
//...
</Auth0Provider


should behave the same