### PR TITLE
Bump Auth0-SPA-JS to 1.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
-        "@auth0/auth0-spa-js": "^1.17.1"
+        "@auth0/auth0-spa-js": "^1.18.0"
       },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^7.1.3",
@@ -58,13 +58,13 @@
       }
     },
     "node_modules/@auth0/auth0-spa-js": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-1.17.1.tgz",
-      "integrity": "sha512-1XfySBfqZnqrWeaCROZ2IMLD+8rQ9TlfttLv0utS91d4rjIKX1g/zTcLYqP68QnqKKGHaMOIee/eQJLnk/o+ow==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-1.18.0.tgz",
+      "integrity": "sha512-Z8ZIzrZJKBHa3yFY/vRJYqg9CbLPwb2sRnouBdfPj8Pas08fwig63mfJKaTusIJC3gQ8xCIwfw4QFo83wpmFkg==",
       "dependencies": {
         "abortcontroller-polyfill": "^1.7.3",
         "browser-tabs-lock": "^1.2.14",
-        "core-js": "^3.16.1",
+        "core-js": "^3.16.3",
         "es-cookie": "^1.3.2",
         "fast-text-encoding": "^1.0.3",
         "promise-polyfill": "^8.2.0",
@@ -16881,13 +16881,13 @@
   },
   "dependencies": {
     "@auth0/auth0-spa-js": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-1.17.1.tgz",
-      "integrity": "sha512-1XfySBfqZnqrWeaCROZ2IMLD+8rQ9TlfttLv0utS91d4rjIKX1g/zTcLYqP68QnqKKGHaMOIee/eQJLnk/o+ow==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-1.18.0.tgz",
+      "integrity": "sha512-Z8ZIzrZJKBHa3yFY/vRJYqg9CbLPwb2sRnouBdfPj8Pas08fwig63mfJKaTusIJC3gQ8xCIwfw4QFo83wpmFkg==",
       "requires": {
         "abortcontroller-polyfill": "^1.7.3",
         "browser-tabs-lock": "^1.2.14",
-        "core-js": "^3.16.1",
+        "core-js": "^3.16.3",
         "es-cookie": "^1.3.2",
         "fast-text-encoding": "^1.0.3",
         "promise-polyfill": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,6 @@
     }
   },
   "dependencies": {
-    "@auth0/auth0-spa-js": "^1.17.1"
+    "@auth0/auth0-spa-js": "^1.18.0"
   }
 }


### PR DESCRIPTION
Bumps SPA-JS to 1.18.0 to bring in the changes for that release (https://github.com/auth0/auth0-spa-js/blob/master/CHANGELOG.md#v1180-2021-09-15)