### PR TITLE
Adds external client

### DIFF
--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -155,6 +155,10 @@ export interface Auth0ProviderOptions {
    */
   connection?: string;
   /**
+   * an external client for usage when auth0 properties are used outside of the react scope
+   */
+  client?: Auth0Client;
+  /**
    * If you need to send custom parameters to the Authorization Server,
    * make sure to use the original parameter name.
    */
@@ -228,12 +232,13 @@ const defaultOnRedirectCallback = (appState?: AppState): void => {
 const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
   const {
     children,
+    client,
     skipRedirectCallback,
     onRedirectCallback = defaultOnRedirectCallback,
     ...clientOpts
   } = opts;
   const [client] = useState(
-    () => new Auth0Client(toAuth0ClientOptions(clientOpts))
+    () => client || new Auth0Client(toAuth0ClientOptions(clientOpts))
   );
   const [state, dispatch] = useReducer(reducer, initialAuthState);
 

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -157,7 +157,7 @@ export interface Auth0ProviderOptions {
   /**
    * an external client for usage when auth0 properties are used outside of the react scope
    */
-  client?: Auth0Client;
+  externalClient?: Auth0Client;
   /**
    * If you need to send custom parameters to the Authorization Server,
    * make sure to use the original parameter name.
@@ -232,13 +232,13 @@ const defaultOnRedirectCallback = (appState?: AppState): void => {
 const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
   const {
     children,
-    client,
+    externalClient,
     skipRedirectCallback,
     onRedirectCallback = defaultOnRedirectCallback,
     ...clientOpts
   } = opts;
   const [client] = useState(
-    () => client || new Auth0Client(toAuth0ClientOptions(clientOpts))
+    () => externalClient || new Auth0Client(toAuth0ClientOptions(clientOpts))
   );
   const [state, dispatch] = useReducer(reducer, initialAuthState);
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Adds an option to receive an external auth0 client as prop

> This could be used to able users (and myself) to have a singular auth0Client that would be used both in the react context (within auth0 provider) and outside of it in JS references.

My use case: I'm initializing many API clients outside of the react scope that needs access to jwt for auth, this jwt is used bother in JS and in the react scope and should be the same.


### References
### Testing

Describe how this can be tested by reviewers:
> This should be testable with the current test suites but with an externally created client.

### Checklist

- [V] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [V] All active GitHub checks for tests, formatting, and security are passing
- [V] The correct base branch is being used, if not `master`
