### PR TITLE
Memoize context value in auth0-provider

### DIFF
--- a/__tests__/auth-provider.test.tsx
+++ b/__tests__/auth-provider.test.tsx
@@ -813,4 +813,20 @@ describe('Auth0Provider', () => {
       },
     });
   });
+
+  it('should not update context value after rerender with no state change', async () => {
+    clientMock.getTokenSilently.mockReturnThis();
+    clientMock.getUser.mockResolvedValue({ name: 'foo', updated_at: '1' });
+    const wrapper = createWrapper();
+    const { waitForNextUpdate, result, rerender } = renderHook(
+      () => useContext(Auth0Context),
+      { wrapper }
+    );
+    await waitForNextUpdate();
+    const memoized = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(memoized);
+  });
 });

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useReducer, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useState,
+} from 'react';
 import {
   Auth0Client,
   Auth0ClientOptions,
@@ -364,21 +370,34 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
     [client]
   );
 
+  const contextValue = useMemo(() => {
+    return {
+      ...state,
+      buildAuthorizeUrl,
+      buildLogoutUrl,
+      getAccessTokenSilently,
+      getAccessTokenWithPopup,
+      getIdTokenClaims,
+      loginWithRedirect,
+      loginWithPopup,
+      logout,
+      handleRedirectCallback,
+    };
+  }, [
+    state,
+    buildAuthorizeUrl,
+    buildLogoutUrl,
+    getAccessTokenSilently,
+    getAccessTokenWithPopup,
+    getIdTokenClaims,
+    loginWithRedirect,
+    loginWithPopup,
+    logout,
+    handleRedirectCallback,
+  ]);
+
   return (
-    <Auth0Context.Provider
-      value={{
-        ...state,
-        buildAuthorizeUrl,
-        buildLogoutUrl,
-        getAccessTokenSilently,
-        getAccessTokenWithPopup,
-        getIdTokenClaims,
-        loginWithRedirect,
-        loginWithPopup,
-        logout,
-        handleRedirectCallback,
-      }}
-    >
+    <Auth0Context.Provider value={contextValue}>
       {children}
     </Auth0Context.Provider>
   );


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

We've seen a few instances where the context value in `Auth0Provider` needs to be memoized, as it is set to a new object value on each re-render and causes instances where we use the auth0 object in `useEffect` or `useCallback` to continuously re-evaluate.

### References

Similar to https://github.com/auth0/auth0-react/pull/150, but now we're memoizing the whole object.

### Testing

Added a new test to `auth0-provider.test` and ran without my changes:

```
 FAIL  __tests__/auth-provider.test.tsx
  ● Auth0Provider › should not update context value after rerender with no state change

    expect(received).toBe(expected) // Object.is equality

    If it should pass with deep equality, replace "toBe" with "toStrictEqual"

    Expected: {"buildAuthorizeUrl": [Function anonymous], "buildLogoutUrl": [Function anonymous], "error": undefined, "getAccessTokenSilently": [Function anonymous], "getAccessTokenWithPopup": [Function anonymous], "getIdTokenClaims": [Function anonymous], "handleRedirectCallback": [Function anonymous], "isAuthenticated": true, "isLoading": false, "loginWithPopup": [Function anonymous], "loginWithRedirect": [Function anonymous], "logout": [Function anonymous], "user": {"name": "foo", "updated_at": "1"}}
    Received: serializes to the same string

      828 |     rerender();
      829 | 
    > 830 |     expect(result.current).toBe(memoized);
          |                            ^
      831 |   });
      832 | });
      833 | 

      at __tests__/auth-provider.test.tsx:830:28
      at fulfilled (__tests__/auth-provider.test.tsx:5:58)
```

then ran again with my changes:

```
 PASS  __tests__/auth-provider.test.tsx
```

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
