### PR TITLE
Make sure handleRedirectCallback is only called once in StrictMode React 18

### DIFF
--- a/__tests__/auth-provider.test.tsx
+++ b/__tests__/auth-provider.test.tsx
@@ -1,5 +1,6 @@
-import { useContext } from 'react';
+import React, { StrictMode, useContext } from 'react';
 import Auth0Context from '../src/auth0-context';
+import { render, waitFor } from '@testing-library/react';
 import { renderHook, act } from '@testing-library/react-hooks';
 import {
   Auth0Client,
@@ -7,6 +8,7 @@ import {
 } from '@auth0/auth0-spa-js';
 import pkg from '../package.json';
 import { createWrapper } from './helpers';
+import { Auth0Provider } from '../src';
 
 const clientMock = jest.mocked(new Auth0Client({ client_id: '', domain: '' }));
 
@@ -853,5 +855,28 @@ describe('Auth0Provider', () => {
     rerender();
 
     expect(result.current).toBe(memoized);
+  });
+
+  it('should only handle redirect callback once', async () => {
+    window.history.pushState(
+      {},
+      document.title,
+      '/?code=__test_code__&state=__test_state__'
+    );
+    expect(window.location.href).toBe(
+      'https://www.example.com/?code=__test_code__&state=__test_state__'
+    );
+    clientMock.handleRedirectCallback.mockResolvedValue({
+      appState: undefined,
+    });
+    render(
+      <StrictMode>
+        <Auth0Provider clientId="__test_client_id__" domain="__test_domain__" />
+      </StrictMode>
+    );
+    await waitFor(() => {
+      expect(clientMock.handleRedirectCallback).toHaveBeenCalledTimes(1);
+      expect(clientMock.getUser).toHaveBeenCalled();
+    });
   });
 });

--- a/__tests__/auth-provider.test.tsx
+++ b/__tests__/auth-provider.test.tsx
@@ -863,9 +863,6 @@ describe('Auth0Provider', () => {
       document.title,
       '/?code=__test_code__&state=__test_state__'
     );
-    expect(window.location.href).toBe(
-      'https://www.example.com/?code=__test_code__&state=__test_state__'
-    );
     clientMock.handleRedirectCallback.mockResolvedValue({
       appState: undefined,
     });

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -3,6 +3,7 @@ import React, {
   useEffect,
   useMemo,
   useReducer,
+  useRef,
   useState,
 } from 'react';
 import {
@@ -240,8 +241,13 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
     () => new Auth0Client(toAuth0ClientOptions(clientOpts))
   );
   const [state, dispatch] = useReducer(reducer, initialAuthState);
+  const didInitialise = useRef(false);
 
   useEffect(() => {
+    if (didInitialise.current) {
+      return;
+    }
+    didInitialise.current = true;
     (async (): Promise<void> => {
       try {
         if (hasAuthParams() && !skipRedirectCallback) {

--- a/static/index.html
+++ b/static/index.html
@@ -133,19 +133,22 @@
         };
 
         return (
-          <Auth0Provider
-            domain={identityProvider.domain}
-            clientId={identityProvider.clientId}
-            redirectUri={window.location.origin}
-            useFormData={true}
-            key={identityProvider.domain}
-          >
-            <Playground onChangeIDP={changeIDP} />
-          </Auth0Provider>
+          <React.StrictMode>
+            <Auth0Provider
+              domain={identityProvider.domain}
+              clientId={identityProvider.clientId}
+              redirectUri={window.location.origin}
+              useFormData={true}
+              key={identityProvider.domain}
+            >
+              <Playground onChangeIDP={changeIDP} />
+            </Auth0Provider>
+          </React.StrictMode>
         );
       };
 
-      ReactDOM.render(<App />, document.getElementById('app'));
+      const root = ReactDOM.createRoot(document.getElementById('app'));
+      root.render(<App />);
     </script>
   </body>
 </html>


### PR DESCRIPTION
### Description

`handleRedirectCallback` can only be called once, multiple invocations will result in "Invalid State" errors since the first invocation has the side effect of clearing the transaction state (SessionStorage or cookies) causing the second invocation to fail.

Because of this side effect `handleRedirectCallback` doesn't play well with the new Reusable State checks in StrictMode. 

When StrictMode remounts the `Auth0Provider`, the user hasn't logged in yet, `handleRedirectCallback` fails and the SDK initialises as logged out before the first `handleRedirectCallback` completes and initialises the SDK as logged in.

One symptom of this is that If you have code that detects if the user is logged out and redirects them to login (like `withAuthenticationRequired` does) you can get in an infinite loop as even successful logins will briefly report failures.

### References

The recommended solution for code that can only be run once is to use a "ref"

<img width="1192" alt="image" src="https://user-images.githubusercontent.com/1299658/165747160-8d4ea971-2d83-4d65-9102-1779c20a6110.png">
reactwg/react-18/discussions/18

Fixes #343 

### Testing

Added test per reactwg/react-18/discussions/17

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
