### PR TITLE
Correctly extend Error for OAuthError

### DIFF
--- a/src/errors.tsx
+++ b/src/errors.tsx
@@ -7,5 +7,8 @@
 export class OAuthError extends Error {
   constructor(public error: string, public error_description?: string) {
     super(error_description || error);
+
+    // https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+    Object.setPrototypeOf(this, OAuthError.prototype);
   }
 }


### PR DESCRIPTION
### Description

Targeting ES5 breaks extending builtins classes. Namely, `new OAuthError() instanceof OAuthError` is false. The recommended workaround is to manually adjust the prototype.

### References

https://github.com/Microsoft/TypeScript-wiki/blob/main/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work

See also auth0-spa-js which implements the same fix: https://github.com/auth0/auth0-spa-js/blob/ab50548/src/errors.ts

### Testing

This cannot be tested as the Jest config transpiles for ES6 which doesn't exhibit the issue. Changing Jest to use ES5 causes other issues (namely Istanbul coverage of the super call).

There is actually an existing test [`should convert OAuth error data to an OAuth JS error`](https://github.com/auth0/auth0-react/blob/05866c0/__tests__/utils.test.tsx#L48) which fails if using ES5. It's unlikely there is a useful test for this specific issue as it's related to build config rather than the actual code.
