### PR TITLE
Remove react-dom from peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,8 +91,7 @@
     "typescript": "^4.6.3"
   },
   "peerDependencies": {
-    "react": "^16.11.0 || ^17 || ^18",
-    "react-dom": "^16.11.0 || ^17 || ^18"
+    "react": "^16.11.0 || ^17 || ^18"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
### Description

Removes `react-dom` as peer dependency

### References

https://github.com/auth0/auth0-react/issues/394

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
