### PR TITLE
[SDK-3666] Support multiple providers

### DIFF
--- a/__tests__/helpers.tsx
+++ b/__tests__/helpers.tsx
@@ -1,12 +1,11 @@
-import { Auth0ClientOptions } from '@auth0/auth0-spa-js';
 import React, { PropsWithChildren } from 'react';
-import Auth0Provider from '../src/auth0-provider';
+import Auth0Provider, { Auth0ProviderOptions } from '../src/auth0-provider';
 
 export const createWrapper = ({
   clientId = '__test_client_id__',
   domain = '__test_domain__',
   ...opts
-}: Partial<Auth0ClientOptions> = {}) => {
+}: Partial<Auth0ProviderOptions> = {}) => {
   return function Wrapper({
     children,
   }: PropsWithChildren<Record<string, unknown>>): JSX.Element {

--- a/__tests__/use-auth.test.tsx
+++ b/__tests__/use-auth.test.tsx
@@ -1,6 +1,8 @@
+import React from 'react';
 import useAuth0 from '../src/use-auth0';
-import { renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
 import { createWrapper } from './helpers';
+import { Auth0ContextInterface, initialContext } from '../src/auth0-context';
 
 describe('useAuth0', () => {
   it('should provide the auth context', async () => {
@@ -8,7 +10,7 @@ describe('useAuth0', () => {
     const {
       result: { current },
       waitForNextUpdate,
-    } = renderHook(useAuth0, { wrapper });
+    } = renderHook(() => useAuth0(), { wrapper });
     await waitForNextUpdate();
     expect(current).toBeDefined();
   });
@@ -16,9 +18,22 @@ describe('useAuth0', () => {
   it('should throw with no provider', () => {
     const {
       result: { current },
-    } = renderHook(useAuth0);
+    } = renderHook(() => useAuth0());
     expect(current.loginWithRedirect).toThrowError(
       'You forgot to wrap your component in <Auth0Provider>.'
     );
+  });
+
+  it('should throw when context is not associated with provider', async () => {
+    const context = React.createContext<Auth0ContextInterface>(initialContext);
+    const wrapper = createWrapper({ context });
+    const {
+      result: { current },
+    } = renderHook(() => useAuth0(), { wrapper });
+    await act(async () => {
+      expect(current.loginWithRedirect).toThrowError(
+        'You forgot to wrap your component in <Auth0Provider>.'
+      );
+    });
   });
 });

--- a/__tests__/use-auth.test.tsx
+++ b/__tests__/use-auth.test.tsx
@@ -36,4 +36,16 @@ describe('useAuth0', () => {
       );
     });
   });
+
+  it('should accept custom auth context', async () => {
+    const context = React.createContext<Auth0ContextInterface>(initialContext);
+    const wrapper = createWrapper({ context });
+    const {
+      result: { current },
+      waitForNextUpdate,
+    } = renderHook(() => useAuth0(context), { wrapper });
+    await waitForNextUpdate();
+    expect(current).toBeDefined();
+    expect(current.loginWithRedirect).not.toThrowError();
+  });
 });

--- a/__tests__/with-auth0.test.tsx
+++ b/__tests__/with-auth0.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom/extend-expect';
 import React, { Component } from 'react';
 import withAuth0, { WithAuth0Props } from '../src/with-auth0';
 import { render, screen } from '@testing-library/react';
+import { Auth0ContextInterface, initialContext } from '../src/auth0-context';
 
 describe('withAuth0', () => {
   it('should wrap a class component', () => {
@@ -11,6 +12,18 @@ describe('withAuth0', () => {
       }
     }
     const WrappedComponent = withAuth0(MyComponent);
+    render(<WrappedComponent />);
+    expect(screen.getByText('hasAuth: true')).toBeInTheDocument();
+  });
+
+  it('should wrap a class component and provide context', () => {
+    const context = React.createContext<Auth0ContextInterface>(initialContext);
+    class MyComponent extends Component<WithAuth0Props> {
+      render(): JSX.Element {
+        return <>hasAuth: {`${!!this.props.auth0}`}</>;
+      }
+    }
+    const WrappedComponent = withAuth0(MyComponent, context);
     render(<WrappedComponent />);
     expect(screen.getByText('hasAuth: true')).toBeInTheDocument();
   });

--- a/__tests__/with-authentication-required.test.tsx
+++ b/__tests__/with-authentication-required.test.tsx
@@ -1,12 +1,13 @@
 import '@testing-library/jest-dom/extend-expect';
 import React from 'react';
 import withAuthenticationRequired from '../src/with-authentication-required';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import { Auth0Client, User } from '@auth0/auth0-spa-js';
 import Auth0Provider from '../src/auth0-provider';
+import { Auth0ContextInterface, initialContext } from '../src/auth0-context';
 
 const mockClient = jest.mocked(new Auth0Client({ client_id: '', domain: '' }));
-
+jest.setTimeout(999999);
 describe('withAuthenticationRequired', () => {
   it('should block access to a private component when not authenticated', async () => {
     mockClient.getUser.mockResolvedValue(undefined);
@@ -218,5 +219,67 @@ describe('withAuthenticationRequired', () => {
     await waitFor(() =>
       expect(mockClient.loginWithRedirect).not.toHaveBeenCalled()
     );
+  });
+
+  it('should provide access depending when the provider associated with the context is authenticated', async () => {
+    // Calls happen up the tree, i.e the first Auth0Provider will get a return value and the second will get undefined
+    mockClient.getUser.mockResolvedValueOnce({ name: '__test_user__' });
+    mockClient.getUser.mockResolvedValueOnce(undefined);
+    const context = React.createContext<Auth0ContextInterface>(initialContext);
+    const MyComponent = (): JSX.Element => <>Private</>;
+    const WrappedComponent = withAuthenticationRequired(MyComponent, {
+      context,
+    });
+    await act(() => {
+      render(
+        <Auth0Provider clientId="__test_client_id__" domain="__test_domain__">
+          <Auth0Provider
+            clientId="__test_client_id__"
+            domain="__test_domain__"
+            context={context}
+          >
+            <WrappedComponent />
+          </Auth0Provider>
+        </Auth0Provider>
+      );
+    });
+
+    await waitFor(() =>
+      expect(mockClient.loginWithRedirect).not.toHaveBeenCalled()
+    );
+    // There should be one call per provider
+    expect(mockClient.getUser).toHaveBeenCalledTimes(2);
+    expect(screen.queryByText('Private')).toBeInTheDocument();
+  });
+
+  it('should block access depending when the provider associated with the context is not authenticated', async () => {
+    // Calls happen up the tree, i.e the first Auth0Provider will get undefined and the second will get a return value
+    mockClient.getUser.mockResolvedValueOnce(undefined);
+    mockClient.getUser.mockResolvedValueOnce({ name: '__test_user__' });
+    const context = React.createContext<Auth0ContextInterface>(initialContext);
+    const MyComponent = (): JSX.Element => <>Private</>;
+    const WrappedComponent = withAuthenticationRequired(MyComponent, {
+      context,
+    });
+    await act(() => {
+      render(
+        <Auth0Provider clientId="__test_client_id__" domain="__test_domain__">
+          <Auth0Provider
+            clientId="__test_client_id__"
+            domain="__test_domain__"
+            context={context}
+          >
+            <WrappedComponent />
+          </Auth0Provider>
+        </Auth0Provider>
+      );
+    });
+
+    await waitFor(() =>
+      expect(mockClient.loginWithRedirect).toHaveBeenCalled()
+    );
+    // There should be one call per provider
+    expect(mockClient.getUser).toHaveBeenCalledTimes(2);
+    expect(screen.queryByText('Private')).not.toBeInTheDocument();
   });
 });

--- a/__tests__/with-authentication-required.test.tsx
+++ b/__tests__/with-authentication-required.test.tsx
@@ -7,7 +7,7 @@ import Auth0Provider from '../src/auth0-provider';
 import { Auth0ContextInterface, initialContext } from '../src/auth0-context';
 
 const mockClient = jest.mocked(new Auth0Client({ client_id: '', domain: '' }));
-jest.setTimeout(999999);
+
 describe('withAuthenticationRequired', () => {
   it('should block access to a private component when not authenticated', async () => {
     mockClient.getUser.mockResolvedValue(undefined);
@@ -221,8 +221,8 @@ describe('withAuthenticationRequired', () => {
     );
   });
 
-  it('should provide access depending when the provider associated with the context is authenticated', async () => {
-    // Calls happen up the tree, i.e the first Auth0Provider will get a return value and the second will get undefined
+  it('should provide access when the provider associated with the context is authenticated', async () => {
+    // Calls happen up the tree, i.e the nested Auth0Provider will get a return value and the top level will get undefined
     mockClient.getUser.mockResolvedValueOnce({ name: '__test_user__' });
     mockClient.getUser.mockResolvedValueOnce(undefined);
     const context = React.createContext<Auth0ContextInterface>(initialContext);
@@ -252,8 +252,8 @@ describe('withAuthenticationRequired', () => {
     expect(screen.queryByText('Private')).toBeInTheDocument();
   });
 
-  it('should block access depending when the provider associated with the context is not authenticated', async () => {
-    // Calls happen up the tree, i.e the first Auth0Provider will get undefined and the second will get a return value
+  it('should block access when the provider associated with the context is not authenticated', async () => {
+    // Calls happen up the tree, i.e the nested Auth0Provider will get undefined and the top level will get a return value
     mockClient.getUser.mockResolvedValueOnce(undefined);
     mockClient.getUser.mockResolvedValueOnce({ name: '__test_user__' });
     const context = React.createContext<Auth0ContextInterface>(initialContext);

--- a/src/auth0-context.tsx
+++ b/src/auth0-context.tsx
@@ -66,9 +66,9 @@ export interface Auth0ContextInterface<TUser extends User = User>
    * the `auth0` cookie.
    */
   getAccessTokenSilently: {
-    (options: GetTokenSilentlyOptions & { detailedResponse: true }): Promise<
-      GetTokenSilentlyVerboseResponse
-    >;
+    (
+      options: GetTokenSilentlyOptions & { detailedResponse: true }
+    ): Promise<GetTokenSilentlyVerboseResponse>;
     (options?: GetTokenSilentlyOptions): Promise<string>;
     (options: GetTokenSilentlyOptions): Promise<
       GetTokenSilentlyVerboseResponse | string
@@ -190,7 +190,7 @@ const stub = (): never => {
 /**
  * @ignore
  */
-const initialContext = {
+export const initialContext = {
   ...initialAuthState,
   buildAuthorizeUrl: stub,
   buildLogoutUrl: stub,

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -167,8 +167,18 @@ export interface Auth0ProviderOptions {
    * Context to be used when creating the Auth0Provider, defaults to the internally created context.
    *
    * This allows multiple Auth0Providers to be nested within the same application, the context value can then be
-   * passed to `useAuth0`, `withAuth0`, or `withAuthenticationRequired` to use that specific Auth0Provider to access
+   * passed to useAuth0, withAuth0, or withAuthenticationRequired to use that specific Auth0Provider to access
    * auth state and methods specifically tied to the provider that the context belongs to.
+   *
+   * When using multiple Auth0Providers in a single application you should do the following to ensure sessions are not
+   * overwritten:
+   *
+   * * Configure a different redirect_uri for each Auth0Provider, and set skipRedirectCallback for each provider to ignore
+   * the others redirect_uri
+   * * If using localstorage for both Auth0Providers, ensure that the audience and scope are different for so that the key
+   * used to store data is different
+   *
+   * For a sample on using multiple Auth0Providers review the [React Account Linking Sample](https://github.com/auth0-samples/auth0-link-accounts-sample/tree/react-variant)
    */
   context?: React.Context<Auth0ContextInterface>;
   /**

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -21,7 +21,10 @@ import {
   GetTokenSilentlyOptions,
   User,
 } from '@auth0/auth0-spa-js';
-import Auth0Context, { RedirectLoginOptions } from './auth0-context';
+import Auth0Context, {
+  Auth0ContextInterface,
+  RedirectLoginOptions,
+} from './auth0-context';
 import { hasAuthParams, loginError, tokenError } from './utils';
 import { reducer } from './reducer';
 import { initialAuthState } from './auth-state';
@@ -161,6 +164,14 @@ export interface Auth0ProviderOptions {
    */
   connection?: string;
   /**
+   * Context to be used when creating the Auth0Provider, defaults to the internally created context.
+   *
+   * This allows multiple Auth0Providers to be nested within the same application, the context value can then be
+   * passed to `useAuth0`, `withAuth0`, or `withAuthenticationRequired` to use that specific Auth0Provider to access
+   * auth state and methods specifically tied to the provider that the context belongs to.
+   */
+  context?: React.Context<Auth0ContextInterface>;
+  /**
    * If you need to send custom parameters to the Authorization Server,
    * make sure to use the original parameter name.
    */
@@ -236,6 +247,7 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
     children,
     skipRedirectCallback,
     onRedirectCallback = defaultOnRedirectCallback,
+    context = Auth0Context,
     ...clientOpts
   } = opts;
   const [client] = useState(
@@ -403,11 +415,7 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
     handleRedirectCallback,
   ]);
 
-  return (
-    <Auth0Context.Provider value={contextValue}>
-      {children}
-    </Auth0Context.Provider>
-  );
+  return <context.Provider value={contextValue}>{children}</context.Provider>;
 };
 
 export default Auth0Provider;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,6 +12,7 @@ export {
 export {
   default as Auth0Context,
   Auth0ContextInterface,
+  initialContext,
   RedirectLoginOptions,
 } from './auth0-context';
 export {

--- a/src/use-auth0.tsx
+++ b/src/use-auth0.tsx
@@ -24,7 +24,9 @@ import Auth0Context, { Auth0ContextInterface } from './auth0-context';
  *
  * TUser is an optional type param to provide a type to the `user` field.
  */
-const useAuth0 = <TUser extends User = User>(): Auth0ContextInterface<TUser> =>
-  useContext(Auth0Context) as Auth0ContextInterface<TUser>;
+const useAuth0 = <TUser extends User = User>(
+  context = Auth0Context
+): Auth0ContextInterface<TUser> =>
+  useContext(context) as Auth0ContextInterface<TUser>;
 
-export default useAuth0;  
+export default useAuth0;

--- a/src/with-auth0.tsx
+++ b/src/with-auth0.tsx
@@ -21,18 +21,22 @@ export interface WithAuth0Props {
  * export default withAuth0(MyComponent);
  * ```
  *
- * Wrap your class components in this Higher Order Component to give them access to the Auth0Context
+ * Wrap your class components in this Higher Order Component to give them access to the Auth0Context.
+ *
+ * Providing a context as the second argument allows you to configure the Auth0Provider the Auth0Context
+ * should come from f you have multiple within your application.
  */
 const withAuth0 = <P extends WithAuth0Props>(
-  Component: ComponentType<P>
+  Component: ComponentType<P>,
+  context = Auth0Context
 ): ComponentType<Omit<P, keyof WithAuth0Props>> => {
   return function WithAuth(props): JSX.Element {
     return (
-      <Auth0Context.Consumer>
+      <context.Consumer>
         {(auth: Auth0ContextInterface): JSX.Element => (
           <Component {...(props as P)} auth0={auth} />
         )}
-      </Auth0Context.Consumer>
+      </context.Consumer>
     );
   };
 };

--- a/src/with-authentication-required.tsx
+++ b/src/with-authentication-required.tsx
@@ -1,6 +1,7 @@
 import React, { ComponentType, useEffect, FC } from 'react';
 import { RedirectLoginOptions, User } from '@auth0/auth0-spa-js';
 import useAuth0 from './use-auth0';
+import Auth0Context, { Auth0ContextInterface } from './auth0-context';
 
 /**
  * @ignore
@@ -65,6 +66,13 @@ export interface WithAuthenticationRequiredOptions {
    * whether or not they are authorized to view the component.
    */
   claimCheck?: (claims?: User) => boolean;
+
+  /**
+   * The context to be used when calling useAuth0, this should only be provided if you are using multiple Auth0Providers
+   * within your application and you wish to tie a specific component to a Auth0Provider other than the Auth0Provider
+   * associated with the default Auth0Context.
+   */
+  context?: React.Context<Auth0ContextInterface>;
 }
 
 /**
@@ -80,13 +88,16 @@ const withAuthenticationRequired = <P extends object>(
   options: WithAuthenticationRequiredOptions = {}
 ): FC<P> => {
   return function WithAuthenticationRequired(props: P): JSX.Element {
-    const { user, isAuthenticated, isLoading, loginWithRedirect } = useAuth0();
     const {
       returnTo = defaultReturnTo,
       onRedirecting = defaultOnRedirecting,
       claimCheck = (): boolean => true,
       loginOptions,
+      context = Auth0Context,
     } = options;
+
+    const { user, isAuthenticated, isLoading, loginWithRedirect } =
+      useAuth0(context);
 
     /**
      * The route is authenticated if the user has valid auth and there are no


### PR DESCRIPTION
### Description

This adds support for multiple instances of `Auth0Provider` being used within an application, this is achieved by providing a `context` parameter (created using `React.createContext`) to the `Auth0Provider`, this same context can then be provided to `useAuth0`, `withAuth0`, and `withAuthenticationRequired` in order to access the authentication state and methods associated with that instance of `Auth0Provider`.

The choice to accept the `context` in the helpers was made to avoid users having to maintain their own versions of these that may deviate from the internal version. Whilst for `useAuth0` and `withAuth0` this was unlikely due to their simple-ness, `withAuthenticationRequired` is more complex so I figured that it was worth it.

### References

#290

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

Alongside this I've also produced a React version of the [account linking sample](https://github.com/auth0-samples/auth0-link-accounts-sample/tree/react-variant) to demonstrate/test this work. In order to run it check out this branch, build the repo and run `npm link` in this repo, and then `npm link @auth0/auth0-react` in the sample.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
