### PR TITLE
chore(ci): use latest docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 parameters:
   docker_image:
     type: string
-    default: circleci/node:16-browsers
+    default: cimg/node:16.17-browsers
 jobs:
   build:
     docker:


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description



Legacy images with the prefix “circleci/” were deprecated in 2021.




### References

https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
