### PR TITLE
Update spa-js and omit onRedirect from exported types

### DIFF
--- a/__tests__/auth-provider.test.tsx
+++ b/__tests__/auth-provider.test.tsx
@@ -319,7 +319,7 @@ describe('Auth0Provider', () => {
     expect(result.current.user).toBe(user);
   });
 
-  it('should update state when using onRedirect', async () => {
+  it('should update state when using openUrl', async () => {
     const user = { name: '__test_user__' };
     clientMock.getUser.mockResolvedValue(user);
     // get logout to return a Promise to simulate async cache.
@@ -333,7 +333,7 @@ describe('Auth0Provider', () => {
     expect(result.current.isAuthenticated).toBe(true);
     await act(async () => {
       // eslint-disable-next-line @typescript-eslint/no-empty-function
-      await result.current.logout({ onRedirect: async () => {} });
+      await result.current.logout({ openUrl: async () => {} });
     });
     expect(result.current.isAuthenticated).toBe(false);
   });
@@ -358,6 +358,28 @@ describe('Auth0Provider', () => {
       await result.current.logout();
     });
     expect(logoutSpy).toHaveBeenCalled();
+  });
+
+  it('should update state for openUrl false', async () => {
+    const user = { name: '__test_user__' };
+    clientMock.getUser.mockResolvedValue(user);
+    const wrapper = createWrapper();
+    const { waitForNextUpdate, result } = renderHook(
+      () => useContext(Auth0Context),
+      { wrapper }
+    );
+    await waitForNextUpdate();
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.user).toBe(user);
+    act(() => {
+      result.current.logout({ openUrl: false });
+    });
+    expect(clientMock.logout).toHaveBeenCalledWith({
+      openUrl: false,
+    });
+    await waitForNextUpdate();
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.user).toBeUndefined();
   });
 
   it('should provide a getAccessTokenSilently method', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
-        "@auth0/auth0-spa-js": "^2.0.0"
+        "@auth0/auth0-spa-js": "^2.0.1"
       },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^13.1.3",
@@ -90,8 +90,9 @@
       }
     },
     "node_modules/@auth0/auth0-spa-js": {
-      "version": "2.0.0",
-      "license": "MIT"
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.0.1.tgz",
+      "integrity": "sha512-ThNsY+T6CTRvpjc4L1G/DBG3AgWsleCbXUJ9rTySCDPmYzASjJlo0H3dilASgrBI6NsvUtQJUF5nQy+AbiFilQ=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.18.6",
@@ -13058,7 +13059,9 @@
       }
     },
     "@auth0/auth0-spa-js": {
-      "version": "2.0.0"
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.0.1.tgz",
+      "integrity": "sha512-ThNsY+T6CTRvpjc4L1G/DBG3AgWsleCbXUJ9rTySCDPmYzASjJlo0H3dilASgrBI6NsvUtQJUF5nQy+AbiFilQ=="
     },
     "@babel/code-frame": {
       "version": "7.18.6",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,6 @@
     }
   },
   "dependencies": {
-    "@auth0/auth0-spa-js": "^2.0.0"
+    "@auth0/auth0-spa-js": "^2.0.1"
   }
 }

--- a/src/auth0-context.tsx
+++ b/src/auth0-context.tsx
@@ -2,16 +2,22 @@ import {
   GetTokenSilentlyOptions,
   GetTokenWithPopupOptions,
   IdToken,
-  LogoutOptions,
+  LogoutOptions as SPALogoutOptions,
   PopupLoginOptions,
   PopupConfigOptions,
   RedirectLoginResult,
   User,
   GetTokenSilentlyVerboseResponse,
-  RedirectLoginOptions,
+  RedirectLoginOptions as SPARedirectLoginOptions,
 } from '@auth0/auth0-spa-js';
 import { createContext } from 'react';
 import { AuthState, initialAuthState } from './auth-state';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface LogoutOptions extends Omit<SPALogoutOptions, 'onRedirect'> {}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface RedirectLoginOptions
+  extends Omit<SPARedirectLoginOptions, 'onRedirect'> {}
 
 /**
  * Contains the authenticated state and authentication methods provided by the `useAuth0` hook.

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -9,16 +9,18 @@ import React, {
 import {
   Auth0Client,
   Auth0ClientOptions,
-  LogoutOptions,
   PopupLoginOptions,
   PopupConfigOptions,
-  RedirectLoginOptions,
   GetTokenWithPopupOptions,
   RedirectLoginResult,
   GetTokenSilentlyOptions,
   User,
 } from '@auth0/auth0-spa-js';
-import Auth0Context, { Auth0ContextInterface } from './auth0-context';
+import Auth0Context, {
+  Auth0ContextInterface,
+  LogoutOptions,
+  RedirectLoginOptions,
+} from './auth0-context';
 import { hasAuthParams, loginError, tokenError } from './utils';
 import { reducer } from './reducer';
 import { initialAuthState } from './auth-state';
@@ -187,7 +189,7 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
   const logout = useCallback(
     async (opts: LogoutOptions = {}): Promise<void> => {
       await client.logout(opts);
-      if (opts.onRedirect) {
+      if (opts.openUrl || opts.openUrl === false) {
         dispatch({ type: 'LOGOUT' });
       }
     },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,13 +13,14 @@ export {
   default as Auth0Context,
   Auth0ContextInterface,
   initialContext,
+  LogoutOptions,
+  RedirectLoginOptions,
 } from './auth0-context';
 export {
   AuthorizationParams,
   PopupLoginOptions,
   PopupConfigOptions,
   GetTokenWithPopupOptions,
-  LogoutOptions,
   LogoutUrlOptions,
   CacheLocation,
   GetTokenSilentlyOptions,
@@ -29,6 +30,5 @@ export {
   InMemoryCache,
   LocalStorageCache,
   Cacheable,
-  RedirectLoginOptions,
 } from '@auth0/auth0-spa-js';
 export { OAuthError } from './errors';

--- a/src/with-authentication-required.tsx
+++ b/src/with-authentication-required.tsx
@@ -1,7 +1,10 @@
 import React, { ComponentType, useEffect, FC } from 'react';
-import { RedirectLoginOptions, User } from '@auth0/auth0-spa-js';
+import { User } from '@auth0/auth0-spa-js';
 import useAuth0 from './use-auth0';
-import Auth0Context, { Auth0ContextInterface } from './auth0-context';
+import Auth0Context, {
+  Auth0ContextInterface,
+  RedirectLoginOptions,
+} from './auth0-context';
 
 /**
  * @ignore


### PR DESCRIPTION
### Description

Updates spa-js to 2.0.1 so that we pull in the `openUrl` update, updates the types so that `LogoutOptions` and `RedirectLoginOptions` are now from auth0-react and omit the `onRedirect` property, and also corrects the check around `openUrl` in light of the changes we made

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
