### PR TITLE
Upgrade @auth0/auth0-spa-js to 1.22.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
-        "@auth0/auth0-spa-js": "^1.22.5"
+        "@auth0/auth0-spa-js": "^1.22.6"
       },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^13.1.3",
@@ -90,13 +90,13 @@
       }
     },
     "node_modules/@auth0/auth0-spa-js": {
-      "version": "1.22.5",
-      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-1.22.5.tgz",
-      "integrity": "sha512-6gaQcd+Eb8ZBcdQkrrm9undM7dY/rPvVdQN8s7rxxrviUCs7OopEygsfSkHf67IP4HtlCiE8dSW5/AipRUOw/A==",
+      "version": "1.22.6",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-1.22.6.tgz",
+      "integrity": "sha512-iL3O0vWanfKFVgy1J2ZHDPlAUK6EVHWEHWS6mUXwHEuPiK39tjlQtyUKQIJI1F5YsZB75ijGgRWMTawSDXlwCA==",
       "dependencies": {
         "abortcontroller-polyfill": "^1.7.3",
         "browser-tabs-lock": "^1.2.15",
-        "core-js": "^3.25.1",
+        "core-js": "^3.25.4",
         "es-cookie": "~1.3.2",
         "fast-text-encoding": "^1.0.6",
         "promise-polyfill": "^8.2.3",
@@ -13678,13 +13678,13 @@
       }
     },
     "@auth0/auth0-spa-js": {
-      "version": "1.22.5",
-      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-1.22.5.tgz",
-      "integrity": "sha512-6gaQcd+Eb8ZBcdQkrrm9undM7dY/rPvVdQN8s7rxxrviUCs7OopEygsfSkHf67IP4HtlCiE8dSW5/AipRUOw/A==",
+      "version": "1.22.6",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-1.22.6.tgz",
+      "integrity": "sha512-iL3O0vWanfKFVgy1J2ZHDPlAUK6EVHWEHWS6mUXwHEuPiK39tjlQtyUKQIJI1F5YsZB75ijGgRWMTawSDXlwCA==",
       "requires": {
         "abortcontroller-polyfill": "^1.7.3",
         "browser-tabs-lock": "^1.2.15",
-        "core-js": "^3.25.1",
+        "core-js": "^3.25.4",
         "es-cookie": "~1.3.2",
         "fast-text-encoding": "^1.0.6",
         "promise-polyfill": "^8.2.3",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,6 @@
     }
   },
   "dependencies": {
-    "@auth0/auth0-spa-js": "^1.22.5"
+    "@auth0/auth0-spa-js": "^1.22.6"
   }
 }


### PR DESCRIPTION
### Description

Updates `@auth0/auth0-spa-js` to `1.22.6`, this version is identical to `1.22.5` but includes an update to the development dependency `jsonwebtoken`.

Even though `1.22.5` was not vulnerable for the related [CVE](https://unit42.paloaltonetworks.com/jsonwebtoken-vulnerability-cve-2022-23529/) because of the fact that `jsonwebtoken` is a devDependency of `@auth0/auth0-spa-js`, we are cutting a release to ensure build tools no longer report our SDK as vulnerable to the mentioned CVE.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
