### PR TITLE
Update the code example for React 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,32 @@ Configure the SDK by wrapping your application in `Auth0Provider`:
 ```jsx
 // src/index.js
 import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { Auth0Provider } from '@auth0/auth0-react';
+import App from './App';
+
+const root = createRoot(document.getElementById('app'));
+
+root.render(
+  <Auth0Provider
+    domain="YOUR_AUTH0_DOMAIN"
+    clientId="YOUR_AUTH0_CLIENT_ID"
+    authorizationParams={{
+      redirect_uri: window.location.origin,
+    }}
+  >
+    <App />
+  </Auth0Provider>
+);
+```
+
+<details>
+<summary>Instructions for React <18</summary>
+<br>
+
+```jsx
+// src/index.js
+import React from 'react';
 import ReactDOM from 'react-dom';
 import { Auth0Provider } from '@auth0/auth0-react';
 import App from './App';
@@ -78,6 +104,7 @@ ReactDOM.render(
   document.getElementById('app')
 );
 ```
+</details>
 
 Use the `useAuth0` hook in your components to access authentication state (`isLoading`, `isAuthenticated` and `user`) and authentication methods (`loginWithRedirect` and `logout`):
 


### PR DESCRIPTION
### Description

`ReactDOM.render` is deprecated in v18

### References

See https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis
fixes #483 
