### PR TITLE
Support redirectUri again in a deprecated way

### DIFF
--- a/__tests__/auth-provider.test.tsx
+++ b/__tests__/auth-provider.test.tsx
@@ -59,6 +59,52 @@ describe('Auth0Provider', () => {
     await waitForNextUpdate();
   });
 
+  it('should support redirectUri', async () => {
+    const opts = {
+      clientId: 'foo',
+      domain: 'bar',
+      redirectUri: 'baz',
+    };
+    const wrapper = createWrapper(opts);
+    const { waitForNextUpdate } = renderHook(() => useContext(Auth0Context), {
+      wrapper,
+    });
+    expect(Auth0Client).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientId: 'foo',
+        domain: 'bar',
+        authorizationParams: {
+          redirect_uri: 'baz',
+        },
+      })
+    );
+    await waitForNextUpdate();
+  });
+
+  it('should support authorizationParams.redirectUri', async () => {
+    const opts = {
+      clientId: 'foo',
+      domain: 'bar',
+      authorizationParams: {
+        redirectUri: 'baz',
+      },
+    };
+    const wrapper = createWrapper(opts);
+    const { waitForNextUpdate } = renderHook(() => useContext(Auth0Context), {
+      wrapper,
+    });
+    expect(Auth0Client).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientId: 'foo',
+        domain: 'bar',
+        authorizationParams: {
+          redirect_uri: 'baz',
+        },
+      })
+    );
+    await waitForNextUpdate();
+  });
+
   it('should pass user agent to Auth0Client', async () => {
     const opts = {
       clientId: 'foo',
@@ -291,6 +337,44 @@ describe('Auth0Provider', () => {
     await result.current.loginWithRedirect({
       authorizationParams: {
         redirect_uri: '__redirect_uri__',
+      },
+    });
+    expect(clientMock.loginWithRedirect).toHaveBeenCalledWith({
+      authorizationParams: {
+        redirect_uri: '__redirect_uri__',
+      },
+    });
+  });
+
+  it('should provide a login method supporting redirectUri', async () => {
+    const wrapper = createWrapper();
+    const { waitForNextUpdate, result } = renderHook(
+      () => useContext(Auth0Context),
+      { wrapper }
+    );
+    await waitForNextUpdate();
+    expect(result.current.loginWithRedirect).toBeInstanceOf(Function);
+    await result.current.loginWithRedirect({
+      redirectUri: '__redirect_uri__',
+    } as never);
+    expect(clientMock.loginWithRedirect).toHaveBeenCalledWith({
+      authorizationParams: {
+        redirect_uri: '__redirect_uri__',
+      },
+    });
+  });
+
+  it('should provide a login method supporting authorizationParams.redirectUri', async () => {
+    const wrapper = createWrapper();
+    const { waitForNextUpdate, result } = renderHook(
+      () => useContext(Auth0Context),
+      { wrapper }
+    );
+    await waitForNextUpdate();
+    expect(result.current.loginWithRedirect).toBeInstanceOf(Function);
+    await result.current.loginWithRedirect({
+      authorizationParams: {
+        redirectUri: '__redirect_uri__',
       },
     });
     expect(clientMock.loginWithRedirect).toHaveBeenCalledWith({

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -21,33 +21,14 @@ import Auth0Context, {
   LogoutOptions,
   RedirectLoginOptions,
 } from './auth0-context';
-import { hasAuthParams, loginError, tokenError } from './utils';
+import {
+  hasAuthParams,
+  loginError,
+  tokenError,
+  deprecateRedirectUri,
+} from './utils';
 import { reducer } from './reducer';
 import { initialAuthState } from './auth-state';
-
-/**
- * @ignore
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function deprecateRedirectUri(options?: any) {
-  if (options?.redirectUri) {
-    console.warn(
-      'Using `redirectUri` has been deprecated, please use `authorizationParams.redirect_uri` instead as `redirectUri` will be no longer supported in a future version'
-    );
-    options.authorizationParams = options.authorizationParams || {};
-    options.authorizationParams.redirect_uri = options.redirectUri;
-    delete options.redirectUri;
-  }
-
-  if (options?.authorizationParams?.redirectUri) {
-    console.warn(
-      'Using `authorizationParams.redirectUri` has been deprecated, please use `authorizationParams.redirect_uri` instead as `authorizationParams.redirectUri` will be removed in a future version'
-    );
-    options.authorizationParams.redirect_uri =
-      options.authorizationParams.redirectUri;
-    delete options.authorizationParams.redirectUri;
-  }
-}
 
 /**
  * The state of the application before the user was redirected to the login page.

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -26,6 +26,30 @@ import { reducer } from './reducer';
 import { initialAuthState } from './auth-state';
 
 /**
+ * @ignore
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function deprecateRedirectUri(options?: any) {
+  if (options?.redirectUri) {
+    console.warn(
+      'Using `redirectUri` has been deprecated, please use `authorizationParams.redirect_uri` instead as `redirectUri` will be no longer supported in a future version'
+    );
+    options.authorizationParams = options.authorizationParams || {};
+    options.authorizationParams.redirect_uri = options.redirectUri;
+    delete options.redirectUri;
+  }
+
+  if (options?.authorizationParams?.redirectUri) {
+    console.warn(
+      'Using `authorizationParams.redirectUri` has been deprecated, please use `authorizationParams.redirect_uri` instead as `authorizationParams.redirectUri` will be removed in a future version'
+    );
+    options.authorizationParams.redirect_uri =
+      options.authorizationParams.redirectUri;
+    delete options.authorizationParams.redirectUri;
+  }
+}
+
+/**
  * The state of the application before the user was redirected to the login page.
  */
 export type AppState = {
@@ -93,6 +117,8 @@ declare const __VERSION__: string;
 const toAuth0ClientOptions = (
   opts: Auth0ProviderOptions
 ): Auth0ClientOptions => {
+  deprecateRedirectUri(opts);
+
   return {
     ...opts,
     auth0Client: {
@@ -163,8 +189,11 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
   }, [client, onRedirectCallback, skipRedirectCallback]);
 
   const loginWithRedirect = useCallback(
-    (opts?: RedirectLoginOptions): Promise<void> =>
-      client.loginWithRedirect(opts),
+    (opts?: RedirectLoginOptions): Promise<void> => {
+      deprecateRedirectUri(opts);
+
+      return client.loginWithRedirect(opts);
+    },
     [client]
   );
 

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -8,18 +8,46 @@ export const hasAuthParams = (searchParams = window.location.search): boolean =>
   (CODE_RE.test(searchParams) || ERROR_RE.test(searchParams)) &&
   STATE_RE.test(searchParams);
 
-const normalizeErrorFn = (fallbackMessage: string) => (
-  error: Error | { error: string; error_description?: string } | ProgressEvent
-): Error => {
-  if ('error' in error) {
-    return new OAuthError(error.error, error.error_description);
-  }
-  if (error instanceof Error) {
-    return error;
-  }
-  return new Error(fallbackMessage);
-};
+const normalizeErrorFn =
+  (fallbackMessage: string) =>
+  (
+    error: Error | { error: string; error_description?: string } | ProgressEvent
+  ): Error => {
+    if ('error' in error) {
+      return new OAuthError(error.error, error.error_description);
+    }
+    if (error instanceof Error) {
+      return error;
+    }
+    return new Error(fallbackMessage);
+  };
 
 export const loginError = normalizeErrorFn('Login failed');
 
 export const tokenError = normalizeErrorFn('Get access token failed');
+
+/**
+ * @ignore
+ * Helper function to map the v1 `redirectUri` option to the v2 `authorizationParams.redirect_uri`
+ * and log a warning.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const deprecateRedirectUri = (options?: any) => {
+  if (options?.redirectUri) {
+    console.warn(
+      'Using `redirectUri` has been deprecated, please use `authorizationParams.redirect_uri` instead as `redirectUri` will be no longer supported in a future version'
+    );
+    options.authorizationParams = options.authorizationParams || {};
+    options.authorizationParams.redirect_uri = options.redirectUri;
+    delete options.redirectUri;
+  }
+
+  if (options?.authorizationParams?.redirectUri) {
+    console.warn(
+      'Using `authorizationParams.redirectUri` has been deprecated, please use `authorizationParams.redirect_uri` instead as `authorizationParams.redirectUri` will be removed in a future version'
+    );
+    options.authorizationParams.redirect_uri =
+      options.authorizationParams.redirectUri;
+    delete options.authorizationParams.redirectUri;
+  }
+};


### PR DESCRIPTION
### Description

With the release of Auth0-React v2, we have renamed redirectUri to redirect_uri and moved it into an authorizationParams property bag.

This has been called out multiple times to be problematic and causing bad DX, especially since the error logging on Auth0 server doesn't point in the correct direction.

We might want to add some deprecation strategy here to help people migrate instead, to ensure we increase DX again.

**Note**: this only patches the constructor and loginWithRedirect. All other methods in Auth0-React v1 were using `redirect_uri` and never even supported `redirectUri`.


### References

#506 

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
