### PR TITLE
Remove useUnknownInCatchVariables to be compliant with TS ^4.4

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,7 @@
     "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "forceConsistentCasingInFileNames": true,
-    "useUnknownInCatchVariables": false
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
### Description

Projects that use typescript in strict mode with a version > 4.4 cannot compile unless they use the `useUnknownInCatchVariables: false` flag (https://github.com/auth0/auth0-react/pull/319).

### References

Original issue: https://github.com/auth0/auth0-react/issues/302 
Typescript changelog: https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#using-unknown-in-catch-variables

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
