### PR TITLE
Update MIGRATION_GUIDE to reference snake_case

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -93,7 +93,7 @@ The above changes affect the following methods:
 
 ### Changes to parameter casing
 
-With the move to placing Auth0 specific properties in the `authorizationParams` object, these properties will now use the casing used by the Auth0 API. This specifically impacts `redirectUri` and `maxAge` as they previously were camelCase but are now kebab-case:
+With the move to placing Auth0 specific properties in the `authorizationParams` object, these properties will now use the casing used by the Auth0 API. This specifically impacts `redirectUri` and `maxAge` as they previously were camelCase but are now snake-case:
 
 - `redirectUri` is now `redirect_uri`
 - `maxAge` is now `max_age`

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -93,7 +93,7 @@ The above changes affect the following methods:
 
 ### Changes to parameter casing
 
-With the move to placing Auth0 specific properties in the `authorizationParams` object, these properties will now use the casing used by the Auth0 API. This specifically impacts `redirectUri` and `maxAge` as they previously were camelCase but are now snake-case:
+With the move to placing Auth0 specific properties in the `authorizationParams` object, these properties will now use the casing used by the Auth0 API. This specifically impacts `redirectUri` and `maxAge` as they previously were camelCase but are now snake_case:
 
 - `redirectUri` is now `redirect_uri`
 - `maxAge` is now `max_age`


### PR DESCRIPTION
 - The Migration guide calls the updated properties in `authorizationParams` kebab-case when they are snake_case.

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
Updates the description of updated properties in `authorizationParams` to 'snake-case' instead of 'kebab-case' in https://github.com/auth0/auth0-react/blob/master/MIGRATION_GUIDE.md#changes-to-parameter-casing


### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
