### PR TITLE
Adding onBeforeAuthentication to the withAuthenticationRequired HOC

### DIFF
--- a/__tests__/with-authentication-required.test.tsx
+++ b/__tests__/with-authentication-required.test.tsx
@@ -66,6 +66,26 @@ describe('withAuthenticationRequired', () => {
     );
   });
 
+  it('should call onBeforeAuthentication before loginWithRedirect', async () => {
+    const callOrder: string[] = [];
+    mockClient.getUser.mockResolvedValue(undefined);
+    mockClient.loginWithRedirect.mockImplementationOnce(async ()=>{ callOrder.push('loginWithRedirect') });
+    const MyComponent = (): JSX.Element => <>Private</>;
+    const OnBeforeAuthentication = jest.fn().mockImplementationOnce(async ()=>{ callOrder.push('onBeforeAuthentication') });
+    const WrappedComponent = withAuthenticationRequired(MyComponent, {
+      onBeforeAuthentication: OnBeforeAuthentication,
+    });
+    render(
+      <Auth0Provider clientId="__test_client_id__" domain="__test_domain__">
+        <WrappedComponent />
+      </Auth0Provider>
+    );
+
+    await waitFor(() => expect(OnBeforeAuthentication).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mockClient.loginWithRedirect).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(callOrder).toEqual(['onBeforeAuthentication', 'loginWithRedirect']));
+  });
+
   it('should pass additional options on to loginWithRedirect', async () => {
     mockClient.getUser.mockResolvedValue(undefined);
     const MyComponent = (): JSX.Element => <>Private</>;

--- a/src/with-authentication-required.tsx
+++ b/src/with-authentication-required.tsx
@@ -11,6 +11,11 @@ import Auth0Context, {
 const defaultOnRedirecting = (): JSX.Element => <></>;
 
 /**
+* @ignore
+*/
+const defaultOnBeforeAuthentication = async (): Promise<void> => {/* noop */};
+
+/**
  * @ignore
  */
 const defaultReturnTo = (): string =>
@@ -51,6 +56,16 @@ export interface WithAuthenticationRequiredOptions {
   /**
    * ```js
    * withAuthenticationRequired(Profile, {
+   *   onBeforeAuthentication: () => { analyticsLibrary.track('login_triggered'); }
+   * })
+   * ```
+   *
+   * Allows executing logic before the user is redirected to the login page.
+   */
+  onBeforeAuthentication?: () => Promise<void>;
+  /**
+   * ```js
+   * withAuthenticationRequired(Profile, {
    *   loginOptions: {
    *     appState: {
    *       customProp: 'foo'
@@ -87,6 +102,7 @@ const withAuthenticationRequired = <P extends object>(
     const {
       returnTo = defaultReturnTo,
       onRedirecting = defaultOnRedirecting,
+      onBeforeAuthentication = defaultOnBeforeAuthentication,
       loginOptions,
       context = Auth0Context,
     } = options;
@@ -106,12 +122,14 @@ const withAuthenticationRequired = <P extends object>(
         },
       };
       (async (): Promise<void> => {
+        await onBeforeAuthentication();
         await loginWithRedirect(opts);
       })();
     }, [
       isLoading,
       isAuthenticated,
       loginWithRedirect,
+      onBeforeAuthentication,
       loginOptions,
       returnTo,
     ]);


### PR DESCRIPTION
### Description
Adds an optional `onBeforeAuthentication` function property to the `withAuthenticationRequired` HOC that is called before navigating to the Auth0 authentication screen from your application. This should not introduce any breaking changes as everything is optional (I used `onRedirecting` for inspiration during my implementation).

I am currently using Auth0's `withAuthenticationRequired` HOC and our product team desperately wants (i.e. see "needs") to fire an event to our analytics provider when a user triggers the authentication process with Auth0. I was considering using [patch-package](https://www.npmjs.com/package/patch-package) in order to introduce this feature for my needs, but decided instead try to contribute to the community!

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
