### PR TITLE
Update EXAMPLES.md

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -311,11 +311,10 @@ const App = () => {
   const orgMatches = url.match(/organization=([^&]+)/);
   if (inviteMatches && orgMatches) {
     loginWithRedirect({
-      authorizationParams: {
-        organization: orgMatches[1],
         invitation: inviteMatches[1],
+        organization: orgMatches[1],
       }
-    });
+    );
   }
   return <div>...</div>;
 };


### PR DESCRIPTION
These docs are out of date. The correct way to pass the invitation and organization params to `loginWithRedirect` is to do so directly, rather than as an object within `authorizationParams`.

This is the only way I've successfully navigated a user to the sign-up screen from an Organization invite. The previous example fails to pass the invitation and organization params to the /authorization endpoint.

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR updates an example of how to accept an invite from an organization, passing the required `invitation` and `organization` parameters to the `loginWithRedirect()` hook. 

Prior to this change, the example shown was to contain these values with an `authorizationParams` parameter. This does not work, the /authorization endpoint fails to successfully read the `invitation` and `organization` params when passed this way, and instead of seeing the expected sign-up screen, a new user, with no account, is prompted to log in (starting with entering their organization - showing that the organization was not successfully passed).

The updated example fixes this issue. When the `invitation` and `organization` params are passed in this way, directly to the `loginWithRedirect()` hook, the two values are received as expected by the /authorization endpoint, and the user is shown the sign-up flow. 


### Testing

I tested this change by troubleshooting why new user Organization invitation emails were not behaving as expected for my application. Prior to this change, I was using the old example of trying to pass the required values through the `authorizationParams` object, which did not work (as described in the description above).

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
