### PR TITLE
Fix warnings during tests

### DIFF
--- a/__tests__/auth-provider.test.tsx
+++ b/__tests__/auth-provider.test.tsx
@@ -60,6 +60,7 @@ describe('Auth0Provider', () => {
   });
 
   it('should support redirectUri', async () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
     const opts = {
       clientId: 'foo',
       domain: 'bar',
@@ -78,10 +79,12 @@ describe('Auth0Provider', () => {
         },
       })
     );
+    expect(warn).toHaveBeenCalled();
     await waitForNextUpdate();
   });
 
   it('should support authorizationParams.redirectUri', async () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
     const opts = {
       clientId: 'foo',
       domain: 'bar',
@@ -102,6 +105,7 @@ describe('Auth0Provider', () => {
         },
       })
     );
+    expect(warn).toHaveBeenCalled();
     await waitForNextUpdate();
   });
 
@@ -347,6 +351,7 @@ describe('Auth0Provider', () => {
   });
 
   it('should provide a login method supporting redirectUri', async () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
     const wrapper = createWrapper();
     const { waitForNextUpdate, result } = renderHook(
       () => useContext(Auth0Context),
@@ -362,9 +367,11 @@ describe('Auth0Provider', () => {
         redirect_uri: '__redirect_uri__',
       },
     });
+    expect(warn).toHaveBeenCalled();
   });
 
   it('should provide a login method supporting authorizationParams.redirectUri', async () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
     const wrapper = createWrapper();
     const { waitForNextUpdate, result } = renderHook(
       () => useContext(Auth0Context),
@@ -382,6 +389,7 @@ describe('Auth0Provider', () => {
         redirect_uri: '__redirect_uri__',
       },
     });
+    expect(warn).toHaveBeenCalled();
   });
 
   it('should provide a logout method', async () => {

--- a/__tests__/helpers.tsx
+++ b/__tests__/helpers.tsx
@@ -16,3 +16,21 @@ export const createWrapper = ({
     );
   };
 };
+
+export interface Defer<TData> {
+  resolve: (value: TData | PromiseLike<TData>) => void;
+  reject: (reason?: unknown) => void;
+  promise: Promise<TData>;
+}
+
+export function defer<TData>() {
+  const deferred: Defer<TData> = {} as unknown as Defer<TData>;
+
+  const promise = new Promise<TData>(function (resolve, reject) {
+    deferred.resolve = resolve;
+    deferred.reject = reject;
+  });
+
+  deferred.promise = promise;
+  return deferred;
+}

--- a/__tests__/with-authentication-required.test.tsx
+++ b/__tests__/with-authentication-required.test.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom/extend-expect';
 import React from 'react';
 import withAuthenticationRequired from '../src/with-authentication-required';
 import { render, screen, waitFor, act } from '@testing-library/react';
-import { Auth0Client} from '@auth0/auth0-spa-js';
+import { Auth0Client, User } from '@auth0/auth0-spa-js';
 import Auth0Provider from '../src/auth0-provider';
 import { Auth0ContextInterface, initialContext } from '../src/auth0-context';
 
@@ -28,11 +28,14 @@ describe('withAuthenticationRequired', () => {
     mockClient.getUser.mockResolvedValue({ name: '__test_user__' });
     const MyComponent = (): JSX.Element => <>Private</>;
     const WrappedComponent = withAuthenticationRequired(MyComponent);
-    render(
-      <Auth0Provider clientId="__test_client_id__" domain="__test_domain__">
-        <WrappedComponent />
-      </Auth0Provider>
-    );
+    await act(() => {
+      render(
+        <Auth0Provider clientId="__test_client_id__" domain="__test_domain__">
+          <WrappedComponent />
+        </Auth0Provider>
+      );
+    });
+
     await waitFor(() =>
       expect(mockClient.loginWithRedirect).not.toHaveBeenCalled()
     );
@@ -41,25 +44,49 @@ describe('withAuthenticationRequired', () => {
     );
   });
 
-  it('should show a custom redirecting message', async () => {
-    mockClient.getUser.mockResolvedValue(
-      Promise.resolve({ name: '__test_user__' })
-    );
+  function defer<TData>() {
+    const deferred: {
+      resolve: (value: TData | PromiseLike<TData>) => void;
+      reject: (reason?: unknown) => void;
+      promise: Promise<TData>;
+    } = {} as any;
+
+    const promise = new Promise<TData>(function (resolve, reject) {
+      deferred.resolve = resolve;
+      deferred.reject = reject;
+    });
+
+    deferred.promise = promise;
+    return deferred;
+  }
+
+  it('should show a custom redirecting message when not authenticated', async () => {
+    const deferred = defer<User>();
+    mockClient.getUser.mockResolvedValue(deferred.promise);
+
     const MyComponent = (): JSX.Element => <>Private</>;
     const OnRedirecting = (): JSX.Element => <>Redirecting</>;
     const WrappedComponent = withAuthenticationRequired(MyComponent, {
       onRedirecting: OnRedirecting,
     });
-    render(
-      <Auth0Provider clientId="__test_client_id__" domain="__test_domain__">
-        <WrappedComponent />
-      </Auth0Provider>
+    const { rerender } = await act(() =>
+      render(
+        <Auth0Provider clientId="__test_client_id__" domain="__test_domain__">
+          <WrappedComponent />
+        </Auth0Provider>
+      )
     );
+
     await waitFor(() =>
       expect(screen.getByText('Redirecting')).toBeInTheDocument()
     );
-    await waitFor(() =>
-      expect(mockClient.loginWithRedirect).not.toHaveBeenCalled()
+
+    deferred.resolve({ name: '__test_user__' });
+
+    rerender(
+      <Auth0Provider clientId="__test_client_id__" domain="__test_domain__">
+        <WrappedComponent />
+      </Auth0Provider>
     );
     await waitFor(() =>
       expect(screen.queryByText('Redirecting')).not.toBeInTheDocument()
@@ -69,9 +96,15 @@ describe('withAuthenticationRequired', () => {
   it('should call onBeforeAuthentication before loginWithRedirect', async () => {
     const callOrder: string[] = [];
     mockClient.getUser.mockResolvedValue(undefined);
-    mockClient.loginWithRedirect.mockImplementationOnce(async ()=>{ callOrder.push('loginWithRedirect') });
+    mockClient.loginWithRedirect.mockImplementationOnce(async () => {
+      callOrder.push('loginWithRedirect');
+    });
     const MyComponent = (): JSX.Element => <>Private</>;
-    const OnBeforeAuthentication = jest.fn().mockImplementationOnce(async ()=>{ callOrder.push('onBeforeAuthentication') });
+    const OnBeforeAuthentication = jest
+      .fn()
+      .mockImplementationOnce(async () => {
+        callOrder.push('onBeforeAuthentication');
+      });
     const WrappedComponent = withAuthenticationRequired(MyComponent, {
       onBeforeAuthentication: OnBeforeAuthentication,
     });
@@ -81,9 +114,15 @@ describe('withAuthenticationRequired', () => {
       </Auth0Provider>
     );
 
-    await waitFor(() => expect(OnBeforeAuthentication).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(mockClient.loginWithRedirect).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(callOrder).toEqual(['onBeforeAuthentication', 'loginWithRedirect']));
+    await waitFor(() =>
+      expect(OnBeforeAuthentication).toHaveBeenCalledTimes(1)
+    );
+    await waitFor(() =>
+      expect(mockClient.loginWithRedirect).toHaveBeenCalledTimes(1)
+    );
+    await waitFor(() =>
+      expect(callOrder).toEqual(['onBeforeAuthentication', 'loginWithRedirect'])
+    );
   });
 
   it('should pass additional options on to loginWithRedirect', async () => {

--- a/__tests__/with-authentication-required.test.tsx
+++ b/__tests__/with-authentication-required.test.tsx
@@ -5,6 +5,7 @@ import { render, screen, waitFor, act } from '@testing-library/react';
 import { Auth0Client, User } from '@auth0/auth0-spa-js';
 import Auth0Provider from '../src/auth0-provider';
 import { Auth0ContextInterface, initialContext } from '../src/auth0-context';
+import { defer } from './helpers';
 
 const mockClient = jest.mocked(new Auth0Client({ clientId: '', domain: '' }));
 
@@ -44,24 +45,8 @@ describe('withAuthenticationRequired', () => {
     );
   });
 
-  function defer<TData>() {
-    const deferred: {
-      resolve: (value: TData | PromiseLike<TData>) => void;
-      reject: (reason?: unknown) => void;
-      promise: Promise<TData>;
-    } = {} as any;
-
-    const promise = new Promise<TData>(function (resolve, reject) {
-      deferred.resolve = resolve;
-      deferred.reject = reject;
-    });
-
-    deferred.promise = promise;
-    return deferred;
-  }
-
   it('should show a custom redirecting message when not authenticated', async () => {
-    const deferred = defer<User>();
+    const deferred = defer<User | undefined>();
     mockClient.getUser.mockResolvedValue(deferred.promise);
 
     const MyComponent = (): JSX.Element => <>Private</>;


### PR DESCRIPTION
### Description

Fixes some warnings occuring during running the tests:

- Not using `act` where we should use it.
- We have our own warnings which polute the test output. So whenever a warning is expected, I mocked the `console.warn` function instead, and verify it's been called.
- Reworked the test to verify a redirect message shows up now that act was added, which is async.

With the above changes, our console output when running the tests is a lot cleaner:

![image](https://github.com/auth0/auth0-react/assets/2146903/8156a392-95bd-4e3c-9aeb-fc585023cb0f)


### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
