### PR TITLE
Fix inconsistent logout function types

### DIFF
--- a/src/auth0-context.tsx
+++ b/src/auth0-context.tsx
@@ -127,7 +127,7 @@ export interface Auth0ContextInterface<TUser extends User = User>
    * If the `logoutParams.federated` option is specified, it also clears the Identity Provider session.
    * [Read more about how Logout works at Auth0](https://auth0.com/docs/logout).
    */
-  logout: (options?: LogoutOptions) => void;
+  logout: (options?: LogoutOptions) => Promise<void>;
 
   /**
    * After the browser redirects back to the callback page,

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -267,7 +267,7 @@ const Auth0Provider = (opts: Auth0ProviderOptions): JSX.Element => {
     [client]
   );
 
-  const contextValue = useMemo(() => {
+  const contextValue = useMemo<Auth0ContextInterface<User>>(() => {
     return {
       ...state,
       getAccessTokenSilently,


### PR DESCRIPTION
### Description

Logout is async, so it shouldn't be marked as void, but `Promise<void>`, like we already do in the provider.

### References

Closes #545 

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
