### PR TITLE
Fix incorrect logout jsdocx example

### DIFF
--- a/src/auth0-context.tsx
+++ b/src/auth0-context.tsx
@@ -119,7 +119,7 @@ export interface Auth0ContextInterface<TUser extends User = User>
 
   /**
    * ```js
-   * auth0.logout({ returnTo: window.location.origin });
+   * auth0.logout({ logoutParams: { returnTo: window.location.origin } });
    * ```
    *
    * Clears the application session and performs a redirect to `/v2/logout`, using


### PR DESCRIPTION
### Description

The example in the jsdocs for logout was incorrect. The `returnTo` parameter has been moved into `logoutParams`
.

### References

#550 

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
