### PR TITLE
bump auth0-spa-js to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
-        "@auth0/auth0-spa-js": "^2.1.0"
+        "@auth0/auth0-spa-js": "^2.1.2"
       },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.0.1",
@@ -77,9 +77,9 @@
       }
     },
     "node_modules/@auth0/auth0-spa-js": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.1.0.tgz",
-      "integrity": "sha512-7cF2NxrslgjArIdBwpNg02atPldpHHOrXxDScL71cbxKuKny3eziZIpNHQAdsPFiLhjKQ+izWmLq2ZRFlYB/eQ=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.1.2.tgz",
+      "integrity": "sha512-xdA65Z/U7++Y7L9Uwh8Q8OVOs6qgFz+fb7GAzHFjpr1icO37B//xdzLXm7ZRgA19RWrsNe1nme3h896igJSvvw=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.18.6",
@@ -12989,9 +12989,9 @@
       }
     },
     "@auth0/auth0-spa-js": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.1.0.tgz",
-      "integrity": "sha512-7cF2NxrslgjArIdBwpNg02atPldpHHOrXxDScL71cbxKuKny3eziZIpNHQAdsPFiLhjKQ+izWmLq2ZRFlYB/eQ=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.1.2.tgz",
+      "integrity": "sha512-xdA65Z/U7++Y7L9Uwh8Q8OVOs6qgFz+fb7GAzHFjpr1icO37B//xdzLXm7ZRgA19RWrsNe1nme3h896igJSvvw=="
     },
     "@babel/code-frame": {
       "version": "7.18.6",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,6 @@
     "react-dom": "^16.11.0 || ^17 || ^18"
   },
   "dependencies": {
-    "@auth0/auth0-spa-js": "^2.1.0"
+    "@auth0/auth0-spa-js": "^2.1.2"
   }
 }


### PR DESCRIPTION
### Description

Bumps SPA-JS to v2.1.2 to include the fix for organizations.

### References

https://github.com/auth0/auth0-spa-js/releases/tag/v2.1.2

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
