### PR TITLE
Update EXAMPLES.md

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -96,8 +96,6 @@ const Posts = () => {
 export default Posts;
 ```
 
-For a more detailed example see how to [create a `useApi` hook for accessing protected APIs with an access token](#create-a-useapi-hook-for-accessing-protected-apis-with-an-access-token).
-
 ## Protecting a route in a `react-router-dom v6` app
 
 We need to access the `useNavigate` hook so we can use `navigate` in `onRedirectCallback` to return us to our `returnUrl`.


### PR DESCRIPTION
Removing the link to useAPI example as it doesn't work - The example was removed: https://github.com/auth0/auth0-react/issues/499

### Description

It looks like the top level example was removed previously, but this link remains. 


### References

https://github.com/auth0/auth0-react/pull/500
