### PR TITLE
Make OAuthError extend GenericError

### DIFF
--- a/__mocks__/@auth0/auth0-spa-js.tsx
+++ b/__mocks__/@auth0/auth0-spa-js.tsx
@@ -27,3 +27,10 @@ export const Auth0Client = jest.fn(() => {
     logout,
   };
 });
+
+export class GenericError extends Error {
+  constructor(public error: string, public error_description: string) {
+    super(error_description);
+    Object.setPrototypeOf(this, GenericError.prototype);
+  }
+}

--- a/src/errors.tsx
+++ b/src/errors.tsx
@@ -7,7 +7,7 @@ import { GenericError } from "@auth0/auth0-spa-js";
  * See: https://openid.net/specs/openid-connect-core-1_0.html#rfc.section.3.1.2.6
  */
 export class OAuthError extends GenericError {
-  constructor(public error: string, public error_description: string = '') {
+  constructor(error: string, error_description?: string) {
     super(error, error_description || error);
 
     // https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work

--- a/src/errors.tsx
+++ b/src/errors.tsx
@@ -1,12 +1,14 @@
+import { GenericError } from "@auth0/auth0-spa-js";
+
 /**
  * An OAuth2 error will come from the authorization server and will have at least an `error` property which will
  * be the error code. And possibly an `error_description` property
  *
  * See: https://openid.net/specs/openid-connect-core-1_0.html#rfc.section.3.1.2.6
  */
-export class OAuthError extends Error {
-  constructor(public error: string, public error_description?: string) {
-    super(error_description || error);
+export class OAuthError extends GenericError {
+  constructor(public error: string, public error_description: string = '') {
+    super(error, error_description || error);
 
     // https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
     Object.setPrototypeOf(this, OAuthError.prototype);


### PR DESCRIPTION
### Description

For consistency, this PR makes OAuthError extend GenericError, which still extends Error.

### References

#636

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
