### PR TITLE
Revert "Make OAuthError extend GenericError"

### DIFF
--- a/__mocks__/@auth0/auth0-spa-js.tsx
+++ b/__mocks__/@auth0/auth0-spa-js.tsx
@@ -27,10 +27,3 @@ export const Auth0Client = jest.fn(() => {
     logout,
   };
 });
-
-export class GenericError extends Error {
-  constructor(public error: string, public error_description: string) {
-    super(error_description);
-    Object.setPrototypeOf(this, GenericError.prototype);
-  }
-}

--- a/src/errors.tsx
+++ b/src/errors.tsx
@@ -1,14 +1,12 @@
-import { GenericError } from "@auth0/auth0-spa-js";
-
 /**
  * An OAuth2 error will come from the authorization server and will have at least an `error` property which will
  * be the error code. And possibly an `error_description` property
  *
  * See: https://openid.net/specs/openid-connect-core-1_0.html#rfc.section.3.1.2.6
  */
-export class OAuthError extends GenericError {
-  constructor(error: string, error_description?: string) {
-    super(error, error_description || error);
+export class OAuthError extends Error {
+  constructor(public error: string, public error_description?: string) {
+    super(error_description || error);
 
     // https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
     Object.setPrototypeOf(this, OAuthError.prototype);


### PR DESCRIPTION
Reverts auth0/auth0-react#638, because we still target ES5 and it broke things. Worth investigating, but can first revert.