### PR TITLE
Update auth0-context.tsx

### DIFF
--- a/src/auth0-context.tsx
+++ b/src/auth0-context.tsx
@@ -38,7 +38,9 @@ export interface Auth0ContextInterface<TUser extends User = User>
    *
    * If refresh tokens are used, the token endpoint is called directly with the
    * 'refresh_token' grant. If no refresh token is available to make this call,
-   * the SDK falls back to using an iframe to the '/authorize' URL.
+   * the SDK will only fall back to using an iframe to the '/authorize' URL if 
+   * the `useRefreshTokensFallback` setting has been set to `true`. By default this
+   * setting is `false`.
    *
    * This method may use a web worker to perform the token call if the in-memory
    * cache is used.


### PR DESCRIPTION
### Description

Clarify the fact that you need to set `useRefreshTokensFallback` to true when using refreshtokens in order for the iframe to be used.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
