### PR TITLE
Workaround for failing "integration test (CRA)"

### DIFF
--- a/cypress/e2e/smoke.cy.ts
+++ b/cypress/e2e/smoke.cy.ts
@@ -8,8 +8,8 @@ if (!EMAIL || !PASSWORD) {
 }
 
 const loginToAuth0 = (): void => {
-  cy.get('.auth0-lock-input-username .auth0-lock-input').clear().type(EMAIL);
-  cy.get('.auth0-lock-input-password .auth0-lock-input').clear().type(PASSWORD);
+  cy.get('.auth0-lock-input-email .auth0-lock-input').clear().type(EMAIL);
+  cy.get('.auth0-lock-input-show-password .auth0-lock-input').clear().type(PASSWORD);
   cy.get('.auth0-lock-submit').click();
 };
 

--- a/cypress/e2e/smoke.cy.ts
+++ b/cypress/e2e/smoke.cy.ts
@@ -8,8 +8,8 @@ if (!EMAIL || !PASSWORD) {
 }
 
 const loginToAuth0 = (): void => {
-  cy.get('.auth0-lock-input-email .auth0-lock-input').clear().type(EMAIL);
-  cy.get('.auth0-lock-input-show-password .auth0-lock-input').clear().type(PASSWORD);
+  cy.get('.auth0-lock-input-username .auth0-lock-input').clear().type(EMAIL);
+  cy.get('.auth0-lock-input-password .auth0-lock-input').clear().type(PASSWORD);
   cy.get('.auth0-lock-submit').click();
 };
 

--- a/examples/cra-react-router/package.json
+++ b/examples/cra-react-router/package.json
@@ -13,6 +13,9 @@
     "react-scripts": "^5.0.1",
     "typescript": "^4.6.3"
   },
+  "devDependencies": {
+    "ajv": "8.16.0"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build"

--- a/examples/gatsby-app/package.json
+++ b/examples/gatsby-app/package.json
@@ -11,7 +11,8 @@
     "react-dom": "file:../../node_modules/react-dom"
   },
   "devDependencies": {
-    "prettier": "2.0.5"
+    "prettier": "2.0.5",
+    "ajv": "8.16.0"
   },
   "keywords": [
     "gatsby"


### PR DESCRIPTION
### Description

> Currently we are unable to merge any PR to the `main` because `integration test (CRA)` and `integration test (Gatsby)` are failing when the Github runs checks. This issue is caused by one of the sub-dependancy (`ajv`) update  in the example app `examples/cra-react-router`. The changes made in the pull-request serve as a temporary workaround rather than a definitive solution.

### References
> Original issue; failing `Integration Tests / Run example tests (pull_request_target)`.
<img width="1728" alt="image" src="https://github.com/auth0/auth0-react/assets/167290944/33b3b279-790d-40af-9159-949dd36ffa26">


### Testing

> With this PR changes, all the integration tests and workflow checks should get passed.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
