### PR TITLE
Fix Typescript compilation for 4.6.3

### DIFF
--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -4,6 +4,15 @@ const CODE_RE = /[?&]code=[^&]+/;
 const STATE_RE = /[?&]state=[^&]+/;
 const ERROR_RE = /[?&]error=[^&]+/;
 
+interface WithError {
+  error: string;
+}
+
+interface WithErrorAndDescription {
+  error: string;
+  error_description: string;
+}
+
 export const hasAuthParams = (searchParams = window.location.search): boolean =>
   (CODE_RE.test(searchParams) || ERROR_RE.test(searchParams)) &&
   STATE_RE.test(searchParams);
@@ -19,15 +28,17 @@ const normalizeErrorFn =
       error !== null &&
       typeof error === 'object' &&
       'error' in error &&
-      typeof error.error === 'string'
+      typeof (error as WithError).error === 'string'
     ) {
       if (
         'error_description' in error &&
-        typeof error.error_description === 'string'
+        typeof (error as WithErrorAndDescription).error_description === 'string'
       ) {
-        return new OAuthError(error.error, error.error_description);
+        const e = error as WithErrorAndDescription;
+        return new OAuthError(e.error, e.error_description);
       }
-      return new OAuthError(error.error);
+      const e = error as WithError;
+      return new OAuthError(e.error);
     }
     return new Error(fallbackMessage);
   };


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Fixes #811. This PR fixes compilation for on Typescript 4.6.3. It still works on 4.9. 

I tried the simplest solution - casting the variable to the known type.


### References

> Include any links supporting this change such as a:
>
> -#811
> - Auth0 Community post
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

1. Change typescript version to 4.6.3 in package.json
2. Change moduleResolution to node in tsconfig.json
3. npm install (may need to clean first)
4. npx tsc -b
5. See no compilation errors

Developed on Ubuntu 22.04.5 LTS. Tested in Chrome 129.0.6668.58 (Official Build) (64-bit). Tested in Firefox 131.0.3 (64-bit).

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
