### PR TITLE
Added Injectable Auth0Client

### DIFF
--- a/__tests__/auth-provider.test.tsx
+++ b/__tests__/auth-provider.test.tsx
@@ -11,7 +11,7 @@ import {
   GetTokenSilentlyVerboseResponse,
 } from '@auth0/auth0-spa-js';
 import pkg from '../package.json';
-import { createWrapper } from './helpers';
+import { createWrapper, createWrapperInjectableClient } from './helpers';
 import { Auth0Provider, useAuth0 } from '../src';
 
 const clientMock = jest.mocked(new Auth0Client({ clientId: '', domain: '' }));
@@ -60,7 +60,9 @@ describe('Auth0Provider', () => {
   });
 
   it('should support redirectUri', async () => {
-    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    const warn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
     const opts = {
       clientId: 'foo',
       domain: 'bar',
@@ -84,7 +86,9 @@ describe('Auth0Provider', () => {
   });
 
   it('should support authorizationParams.redirectUri', async () => {
-    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    const warn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
     const opts = {
       clientId: 'foo',
       domain: 'bar',
@@ -304,6 +308,33 @@ describe('Auth0Provider', () => {
     expect(result.current.user).toBe(user);
   });
 
+  it('should login with a popup for injectable client', async () => {
+    clientMock.getUser.mockResolvedValue(undefined);
+    const wrapper = createWrapperInjectableClient({
+      client: new Auth0Client({
+        clientId: '__test_client_id__',
+        domain: '__test_domain__',
+      }),
+    });
+    const { waitForNextUpdate, result } = renderHook(
+      () => useContext(Auth0Context),
+      { wrapper }
+    );
+    await waitForNextUpdate();
+    expect(result.current.user).toBeUndefined();
+    const user = { name: '__test_user__' };
+    clientMock.getUser.mockResolvedValue(user);
+    act(() => {
+      result.current.loginWithPopup();
+    });
+    expect(result.current.isLoading).toBe(true);
+    await waitForNextUpdate();
+    expect(result.current.isLoading).toBe(false);
+    expect(clientMock.loginWithPopup).toHaveBeenCalled();
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.user).toBe(user);
+  });
+
   it('should handle errors when logging in with a popup', async () => {
     clientMock.getUser.mockResolvedValue(undefined);
     const wrapper = createWrapper();
@@ -351,7 +382,9 @@ describe('Auth0Provider', () => {
   });
 
   it('should provide a login method supporting redirectUri', async () => {
-    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    const warn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
     const wrapper = createWrapper();
     const { waitForNextUpdate, result } = renderHook(
       () => useContext(Auth0Context),
@@ -371,7 +404,9 @@ describe('Auth0Provider', () => {
   });
 
   it('should provide a login method supporting authorizationParams.redirectUri', async () => {
-    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    const warn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
     const wrapper = createWrapper();
     const { waitForNextUpdate, result } = renderHook(
       () => useContext(Auth0Context),

--- a/__tests__/helpers.tsx
+++ b/__tests__/helpers.tsx
@@ -1,5 +1,9 @@
 import React, { PropsWithChildren } from 'react';
-import Auth0Provider, { Auth0ProviderOptions } from '../src/auth0-provider';
+import Auth0Provider, {
+  Auth0ProviderInjectableClientOptions,
+  Auth0ProviderOptions,
+} from '../src/auth0-provider';
+import { Auth0Client } from '@auth0/auth0-spa-js';
 
 export const createWrapper = ({
   clientId = '__test_client_id__',
@@ -11,6 +15,23 @@ export const createWrapper = ({
   }: PropsWithChildren<Record<string, unknown>>): JSX.Element {
     return (
       <Auth0Provider domain={domain} clientId={clientId} {...opts}>
+        {children}
+      </Auth0Provider>
+    );
+  };
+};
+
+export const createWrapperInjectableClient = ({
+  client,
+  ...opts
+}: Omit<Partial<Auth0ProviderInjectableClientOptions>, 'client'> & {
+  client: Auth0Client;
+}) => {
+  return function Wrapper({
+    children,
+  }: PropsWithChildren<Record<string, unknown>>): JSX.Element {
+    return (
+      <Auth0Provider client={client} {...opts}>
         {children}
       </Auth0Provider>
     );

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -88,13 +88,10 @@ export interface Auth0ProviderOptions extends Auth0ClientOptions {
 
 // Define types for clarity
 export type Auth0ProviderLegacyOptions = Auth0ProviderOptions;
-export type Auth0ProviderInjectableClientOptions = {
-  client: Auth0Client;
-  context?: React.Context<Auth0ContextInterface>;
-  children?: React.ReactNode;
-  skipRedirectCallback?: boolean;
-  onRedirectCallback?: (appState?: AppState, user?: User) => void;
-};
+export type Auth0ProviderInjectableClientOptions = Exclude<
+  Auth0ProviderOptions,
+  keyof Auth0ClientOptions
+> & { client: Auth0Client };
 
 // Combined type for the overload implementation
 export type CombinedAuth0ProviderOptions =


### PR DESCRIPTION
### Description

This PR introduces changes to enable dependency injection for the Auth0 client, while maintaining backward compatibility with existing functionality.

The goal is to allow the Auth0 client to be used outside of the React lifecycle, such as in React Router data loaders, without impacting current behavior.

There are no breaking changes introduced, and the API remains the same for users relying on the current behavior.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not the default branch
