### PR TITLE
Clear auth params from URL parameters when redirectCallback fails

### DIFF
--- a/__tests__/auth-provider.test.tsx
+++ b/__tests__/auth-provider.test.tsx
@@ -225,7 +225,7 @@ describe('Auth0Provider', () => {
     });
   });
 
-  it('should handle redirect callback errors', async () => {
+  it('should handle redirect callback errors and clear the url', async () => {
     window.history.pushState(
       {},
       document.title,
@@ -244,6 +244,7 @@ describe('Auth0Provider', () => {
       expect(() => {
         throw result.current.error;
       }).toThrowError('__test_error__');
+      expect(window.location.href).toBe('https://www.example.com/');
     });
   });
 

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -157,12 +157,12 @@ const Auth0Provider = (opts: Auth0ProviderOptions) => {
     }
     didInitialise.current = true;
     (async (): Promise<void> => {
+      let appState: AppState | undefined
+      let user: User | undefined;
       try {
-        let user: User | undefined;
         if (hasAuthParams() && !skipRedirectCallback) {
-          const { appState } = await client.handleRedirectCallback();
+          appState = (await client.handleRedirectCallback()).appState;
           user = await client.getUser();
-          onRedirectCallback(appState, user);
         } else {
           await client.checkSession();
           user = await client.getUser();
@@ -170,6 +170,8 @@ const Auth0Provider = (opts: Auth0ProviderOptions) => {
         dispatch({ type: 'INITIALISED', user });
       } catch (error) {
         handleError(loginError(error));
+      } finally {
+        onRedirectCallback(appState, user);
       }
     })();
   }, [client, onRedirectCallback, skipRedirectCallback, handleError]);


### PR DESCRIPTION
### Description

Currently, auth params are kept in the URL when logging in fails (i.e., the handle redirect callback fails). Even refreshing the page afterwards won't clear the auth params. Changing this behavior application-side is also difficult, as there is no callback to hook into and clear the auth codes manually.

This PR changes the `onRedirectCallback` to be called regardless of whether the handle redirect callback succeeds or not. If it fails, no app state nor user is passed to the callback. This works with the existing function signature.

It does change the semantics slightly, though. If `onRedirectCallback` throws an exception, it won't be caught anymore (as it  would be right now). Also, `onRedirectCallback` being called doesn't in itself imply that handling the callback succeeded. The application will need to look at the parameter values and the overall hook state to determine whether logging in succeeded or not.

Another alternative would be to introduce a second callback, something along the lines of `onRedirectCallbackError` that is called with the error. This would make the `onRedirectCallback` behavior stay exactly the same by preserving error catching and when it's called. On the other hand, it would be a larger change in the AuthProvider signature (hence the simpler variant here).

### Testing

* Automated testing: please see the change to the unit test
* Manual testing: provide faulty auth params as URL parameters that trigger a handle redirect callback, but will fail. Observe that the current version will keep the URL parameters in the URL bar, while the URL parameters are cleared with this PR.

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
