### PR TITLE
feat: add support for pre-configured Auth0Client instance in Auth0Pro…

### DIFF
--- a/__tests__/auth-provider.test.tsx
+++ b/__tests__/auth-provider.test.tsx
@@ -60,6 +60,22 @@ describe('Auth0Provider', () => {
     });
   });
 
+  it('should support Auth0Client instance', async () => {
+    const opts = {
+      clientId: 'foo',
+      domain: 'bar',
+      client: clientMock,
+    };
+    const wrapper = createWrapper(opts);
+    renderHook(() => useContext(Auth0Context), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(Auth0Client).not.toHaveBeenCalled();
+    });
+  });
+
   it('should support redirectUri', async () => {
     const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
     const opts = {

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -84,6 +84,33 @@ export interface Auth0ProviderOptions<TUser extends User = User> extends Auth0Cl
    * For a sample on using multiple Auth0Providers review the [React Account Linking Sample](https://github.com/auth0-samples/auth0-link-accounts-sample/tree/react-variant)
    */
   context?: React.Context<Auth0ContextInterface<TUser>>;
+  /**
+   * A pre-configured Auth0Client instance to use for authentication operations.
+   *
+   * When provided, this client will be used instead of creating a new one internally.
+   * This is useful for:
+   * - Sharing a single Auth0Client instance across multiple components
+   * - Using a client with custom configuration or advanced setup
+   * - Testing scenarios where you need to inject a mock client
+   * - Scenarios where you need fine-grained control over client initialization timing
+   *
+   * If not provided, the Auth0Provider will automatically create a new Auth0Client
+   * instance using the other configuration options passed to the provider.
+   *
+   * @example
+   * ```tsx
+   * const customClient = new Auth0Client({
+   *   domain: 'your-domain.auth0.com',
+   *   clientId: 'your-client-id',
+   *   // ... other options
+   * });
+   *
+   * <Auth0Provider client={customClient}>
+   *   <App />
+   * </Auth0Provider>
+   * ```
+   */
+  client?: Auth0Client;
 }
 
 /**
@@ -138,10 +165,11 @@ const Auth0Provider = <TUser extends User = User>(opts: Auth0ProviderOptions<TUs
     skipRedirectCallback,
     onRedirectCallback = defaultOnRedirectCallback,
     context = Auth0Context,
+    client: providedClient,
     ...clientOpts
   } = opts;
   const [client] = useState(
-    () => new Auth0Client(toAuth0ClientOptions(clientOpts))
+    () => providedClient ?? new Auth0Client(toAuth0ClientOptions(clientOpts))
   );
   const [state, dispatch] = useReducer(reducer<TUser>, initialAuthState  as AuthState<TUser>);
   const didInitialise = useRef(false);


### PR DESCRIPTION
## Add support for pre-configured Auth0Client instance in Auth0Provider

### Description

This PR introduces a new optional `client` prop to the `Auth0Provider` component, allowing developers to pass a pre-configured `Auth0Client` instance instead of having the provider create one internally.

#### Changes
- Added `client` prop to `Auth0ProviderOptions` interface with comprehensive JSDoc documentation
- Updated `Auth0Provider` component to use the provided client instance when available, falling back to creating a new one if not provided
- Added test coverage to verify that when a client instance is provided, no new `Auth0Client` is instantiated

#### Use Cases
This enhancement enables several important scenarios:
- Shared client instances: Use a single Auth0Client inside and outside a React app scope
- Custom configuration: Pass clients with advanced or specialized configuration
- Testing: Inject mock clients for unit and integration tests
- Fine-grained control: Manage client initialization timing externally

##### Example Usage
```ts
const domain = 'your-domain.auth0.com';
const clientId = 'your-client-id';
const customClient = new Auth0Client({
  domain,
  clientId,
  // ... other options
});

<Auth0Provider client={customClient} domain={domain} clientId={clientId}>
  <App />
</Auth0Provider>
```

#### Backward Compatibility
This change is fully backward compatible. Existing implementations will continue to work unchanged, as the client prop is optional and the provider maintains its existing behavior when not provided.

### Testing

- Added unit test to verify that when a `client` prop is provided, no new `Auth0Client` instance is created
- Existing tests continue to pass, ensuring no regression in current functionality

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
