### PR TITLE
fix: recreate Auth0Client when configuration props change

### DIFF
--- a/__tests__/auth-provider.test.tsx
+++ b/__tests__/auth-provider.test.tsx
@@ -1095,13 +1095,19 @@ describe('Auth0Provider - useMemo dependency behavior', () => {
     window.history.pushState({}, document.title, '/');
   });
 
-  const TestComponent = ({ 
-    clientId = '__test_client_id__', 
+  interface TestComponentProps {
+    clientId?: string;
+    audience?: string;
+    scope?: string;
+  }
+
+  const TestComponent: React.FC<TestComponentProps> = ({
+    clientId = '__test_client_id__',
     audience = '__test_audience__',
     scope = 'read:profile openid'
   }) => (
-    <Auth0Provider 
-      domain="__test_domain__" 
+    <Auth0Provider
+      domain="__test_domain__"
       clientId={clientId}
       authorizationParams={{
         audience,

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -4,7 +4,6 @@ import React, {
   useMemo,
   useReducer,
   useRef,
-  useState,
 } from 'react';
 import {
   Auth0Client,
@@ -140,8 +139,18 @@ const Auth0Provider = <TUser extends User = User>(opts: Auth0ProviderOptions<TUs
     context = Auth0Context,
     ...clientOpts
   } = opts;
-  const [client] = useState(
-    () => new Auth0Client(toAuth0ClientOptions(clientOpts))
+  const client = useMemo(
+    () => new Auth0Client(toAuth0ClientOptions(clientOpts)),
+    [
+      clientOpts.domain,
+      clientOpts.clientId,
+      clientOpts.authorizationParams?.audience,
+      clientOpts.authorizationParams?.scope,
+      clientOpts.authorizationParams?.redirect_uri,
+      clientOpts.cacheLocation,
+      clientOpts.useRefreshTokens,
+      clientOpts.useCookiesForTransactions,
+    ]
   );
   const [state, dispatch] = useReducer(reducer<TUser>, initialAuthState  as AuthState<TUser>);
   const didInitialise = useRef(false);

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -147,9 +147,6 @@ const Auth0Provider = <TUser extends User = User>(opts: Auth0ProviderOptions<TUs
       clientOpts.authorizationParams?.audience,
       clientOpts.authorizationParams?.scope,
       clientOpts.authorizationParams?.redirect_uri,
-      clientOpts.cacheLocation,
-      clientOpts.useRefreshTokens,
-      clientOpts.useCookiesForTransactions,
     ]
   );
   const [state, dispatch] = useReducer(reducer<TUser>, initialAuthState  as AuthState<TUser>);


### PR DESCRIPTION
## Summary

This PR improves how the `Auth0Client` is created in the `Auth0Provider` component. It replaces `useState` with `useMemo` to ensure the client is properly recreated when key props (`domain`, `clientId`, `audience`, `scope`, etc.) change. This makes the component behavior more predictable and correct when props are updated.

Fixes: [#830](https://github.com/auth0/auth0-react/issues/830)

---

## Changes

- Refactored `Auth0Provider` to use `useMemo` for `Auth0Client` instantiation.
- Removed unused `useState` import from `src/auth0-provider.tsx`.

---

## Tests

- Added a test suite in `__tests__/auth-provider.test.tsx` to verify that the `Auth0Client` is correctly recreated when `clientId`, `audience`, or `scope` props change.
