### PR TITLE
Bump auth0-spa-js for connected account updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.7.0",
       "license": "MIT",
       "dependencies": {
-        "@auth0/auth0-spa-js": "^2.6.0"
+        "@auth0/auth0-spa-js": "^2.7.0"
       },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.0.1",
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/@auth0/auth0-spa-js": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.6.0.tgz",
-      "integrity": "sha512-zxqgmXObIv4V8kt6Dz2MU4lWTH72b3RL7Po5C+HDU8zCg5rm5VL/aYXIo407B0uVUIFH44ph0tusMLBoILg7kw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.7.0.tgz",
+      "integrity": "sha512-o29ZDbUUCJcEXeBP5LPuacbP28BkNroHuq3jfKbNjFiiWjmrCe95jwPAYb6+9PGyEbs8Wva4fGkVSNZ2HZFEGA==",
       "license": "MIT",
       "dependencies": {
         "browser-tabs-lock": "^1.2.15",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,6 @@
     "react-dom": "^16.11.0 || ^17 || ^18 || ^19"
   },
   "dependencies": {
-    "@auth0/auth0-spa-js": "^2.6.0"
+    "@auth0/auth0-spa-js": "^2.7.0"
   }
 }


### PR DESCRIPTION
### Update to auth0-spa-js@2.7.0

**Added**
- Retry when DPoP nonce is expired [\#1445](https://github.com/auth0/auth0-spa-js/pull/1445) ([adamjmcgrath](https://github.com/adamjmcgrath))
-  Support mix of DPoP and Bearer in the fetcher [\#1442](https://github.com/auth0/auth0-spa-js/pull/1442) ([adamjmcgrath](https://github.com/adamjmcgrath))

**Fixed**
- Fix MRRT with default audience in worker [\#1439](https://github.com/auth0/auth0-spa-js/pull/1439) ([aridibag](https://github.com/aridibag))
- Fetcher: fix incorrect URL building when `baseUrl` is present [\#1435](https://github.com/auth0/auth0-spa-js/pull/1435) ([martinml](https://github.com/martinml))


[ESD-52771]: https://auth0team.atlassian.net/browse/ESD-52771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ