### PR TITLE
feat: upload Cypress screenshots on test failure

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -65,3 +65,13 @@ jobs:
 
       - name: Run integration test (Gatsby)
         run: npm run test:gatsby
+
+      - name: Upload Cypress screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-screenshots-${{ github.run_id }}
+          path: cypress/screenshots
+          retention-days: 30
+          compression-level: 6
+          if-no-files-found: ignore


### PR DESCRIPTION
Automatically upload Cypress screenshots when integration tests fail, with:

- 30-day retention and compression level 6
- Graceful skip if screenshots folder is empty
- Simplified workflow without per-step outcome checks

Helps debugging CI test failures for CRA, NextJS, and Gatsby apps.