### PR TITLE
fix: prevent unnecessary user object updates causing infinite loops

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "2.11.0",
       "license": "MIT",
       "dependencies": {
-        "@auth0/auth0-spa-js": "^2.11.0"
+        "@auth0/auth0-spa-js": "^2.11.0",
+        "lodash-es": "^4.17.22"
       },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.0.1",
@@ -19,6 +20,7 @@
         "@testing-library/jest-dom": "6.8.0",
         "@testing-library/react": "16.3.0",
         "@types/jest": "^29.5.14",
+        "@types/lodash-es": "^4.17.12",
         "@types/react": "19.1.8",
         "@types/react-dom": "19.1.6",
         "@typescript-eslint/eslint-plugin": "^8.36.0",
@@ -1680,6 +1682,23 @@
         "@types/node": "*",
         "@types/tough-cookie": "*",
         "parse5": "^7.0.0"
+      }
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-FOvQ0YPD5NOfPgMzJihoT+Za5pdkDJWcbpuj1DjaKZIr/gxodQjY/uWEFlTNqW2ugXHUiL8lRQgw63dzKHZdeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
       }
     },
     "node_modules/@types/node": {
@@ -8456,6 +8475,12 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.22",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.22.tgz",
+      "integrity": "sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==",
       "license": "MIT"
     },
     "node_modules/lodash.defaults": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@testing-library/jest-dom": "6.8.0",
     "@testing-library/react": "16.3.0",
     "@types/jest": "^29.5.14",
+    "@types/lodash-es": "^4.17.12",
     "@types/react": "19.1.8",
     "@types/react-dom": "19.1.6",
     "@typescript-eslint/eslint-plugin": "^8.36.0",
@@ -95,6 +96,7 @@
     "react-dom": "^16.11.0 || ^17 || ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
   },
   "dependencies": {
-    "@auth0/auth0-spa-js": "^2.11.0"
+    "@auth0/auth0-spa-js": "^2.11.0",
+    "lodash-es": "^4.17.22"
   }
 }

--- a/src/reducer.tsx
+++ b/src/reducer.tsx
@@ -1,5 +1,6 @@
 import { User } from '@auth0/auth0-spa-js';
 import { AuthState } from './auth-state';
+import { isEqual } from 'lodash-es';
 
 type Action =
   | { type: 'LOGIN_POPUP_STARTED' }
@@ -35,7 +36,7 @@ export const reducer = <TUser extends User = User>(state: AuthState<TUser>, acti
       };
     case 'HANDLE_REDIRECT_COMPLETE':
     case 'GET_ACCESS_TOKEN_COMPLETE':
-      if (state.user === action.user) {
+      if (isEqual(state.user, action.user)) {
         return state;
       }
       return {


### PR DESCRIPTION
## Problem
When calling `getAccessTokenSilently()`, the reducer creates a new user object reference even when the user data hasn't changed. This causes infinite loops in `useEffect` hooks that depend on the `user` object.

Example scenario:
```tsx
const { user, getAccessTokenSilently } = useAuth0();

useEffect(() => {
  const token = await getAccessTokenSilently();
  myFunction(token, user);
}, [user, getAccessTokenSilently]); // Infinite loop!
```

## Solution
Use deep equality comparison (`isEqual` from `lodash-es`) instead of reference equality (`===`) when checking if the user object has changed in the reducer.

## Changes
- Added `lodash-es` dependency for deep equality checking
- Updated `GET_ACCESS_TOKEN_COMPLETE` and `HANDLE_REDIRECT_COMPLETE` cases in reducer to use `isEqual`
- State is only updated when user content actually changes
- Tree-shakeable import adds ~1.2 KB gzipped to bundle size

## Testing
- [x] Existing tests pass
- [x] No breaking changes
- [x] Fixes infinite loop scenario

Fixes #787