### PR TITLE
chore: add engines field to specify Node.js version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "name": "@auth0/auth0-react",
   "version": "2.11.0",
   "description": "Auth0 SDK for React Single Page Applications (SPA)",
+  "engines": {
+    "node": ">=18.18.0"
+  },
   "keywords": [
     "auth0",
     "login",


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
This PR adds the engines field to [package.json](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to explicitly specify the minimum Node.js version requirement.

### Problem:

- Developers using Node.js versions below 18.18.0 encounter confusing EBADENGINE warnings from @typescript-eslint/* packages without a clear indication of the root cause
- The CI pipeline uses Node 18, but this requirement was not documented, leading to "works in CI but not locally" issues

### Solution: 
```
"engines": {
  "node": ">=18.18.0"
}
```

### Why 18.18.0?
- Aligns with @typescript-eslint/* packages which require ^18.18.0 || ^20.9.0 || >=21.1.0
- Matches the Node version used in CI workflows (node-version: 18)

### Impact:
- Non-breaking: The engines field only produces warnings by default, not hard failures
- Users can still install with --ignore-engines if needed
- Improves developer experience by making implicit requirements explicit

### References
- Node.js 18.18.0 release: [https://nodejs.org/en/blog/release/v18.18.0](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
