### PR TITLE
chore: configure Dependabot to group React updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,8 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"


### PR DESCRIPTION
## Summary
- Configures Dependabot to group `react` and `react-dom` updates into a single PR
- Prevents version mismatch failures in CI when these packages are updated separately

## Context
PRs #989 and #990 were created separately for `react` and `react-dom` updates, causing CI failures due to peer dependency version mismatches. This configuration ensures both packages are updated together in future Dependabot PRs.

## Changes
- Added `groups` configuration to `.github/dependabot.yml` for React packages