### PR TITLE
test: fix flaky logout test race condition

### DIFF
--- a/__tests__/auth-provider.test.tsx
+++ b/__tests__/auth-provider.test.tsx
@@ -491,6 +491,7 @@ describe('Auth0Provider', () => {
     );
     await waitFor(() => {
       expect(result.current.logout).toBeInstanceOf(Function);
+      expect(result.current.isAuthenticated).toBe(true);
     });
     await act(() => {
       result.current.logout();


### PR DESCRIPTION
## Summary
Fixes intermittent test failure in `should provide a logout method` by waiting for authentication to complete before calling logout.

## Changes
Added `isAuthenticated` check to the existing `waitFor` block to ensure the provider has finished initializing before testing logout behavior.

```typescript
await waitFor(() => {
  expect(result.current.logout).toBeInstanceOf(Function);
  expect(result.current.isAuthenticated).toBe(true);
});
```