### PR TITLE
fix: update default Node version to 22 in workflow configurations

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -5,7 +5,7 @@ inputs:
   node:
     description: The Node version to use
     required: false
-    default: 18
+    default: 22
 
 runs:
   using: composite

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
   rl-scanner:
     uses: ./.github/workflows/rl-secure.yml
     with:
-      node-version: 18
+      node-version: 22
       artifact-name: 'auth0-react.tgz'
     secrets:
       RLSECURE_LICENSE: ${{ secrets.RLSECURE_LICENSE }}
@@ -30,7 +30,7 @@ jobs:
     uses: ./.github/workflows/npm-release.yml
     needs: rl-scanner
     with:
-      node-version: 18
+      node-version: 22
       require-build: true
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

Release workflow failed because npm@11 requires Node.js >=20.17.0, but we were using Node.js 18.

## Solution

Updated Node.js version from 18 to 22 in:
- `.github/workflows/release.yml`
- `.github/actions/build/action.yml`

Aligns with the same change made in [auth0-spa-js#1498](https://github.com/auth0/auth0-spa-js/pull/1498).

Workflow failure - https://github.com/auth0/auth0-react/actions/runs/21427941328
