### PR TITLE
fix: use hyphen instead of underscore for rl-wrapper suppress-output flag

### DIFF
--- a/.github/actions/rl-scanner/action.yml
+++ b/.github/actions/rl-scanner/action.yml
@@ -53,7 +53,7 @@ runs:
           --repository "${{ github.repository }}" \
           --commit "${{ github.sha }}" \
           --build-env "github_actions" \
-          --suppress_output
+          --suppress-output
 
         # Check the outcome of the scanner
         if [ $? -ne 0 ]; then


### PR DESCRIPTION
## Summary

- Fixes the \`rl-scanner\` CI job failing after the rl-wrapper upgrade
- The newer version changed the CLI flag from \`--suppress_output\` to \`--suppress-output\`

## Test plan

- [ ] Verify the \`rl-scanner / Run Reversing Labs Scanner\` CI job passes after merge