### PR TITLE
fix(security): add .npmrc with ignore-scripts=true

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install Cypress binary
+        run: npx cypress install
+
       - name: Build SDK
         run: npm run build
 

--- a/.gitignore
+++ b/.gitignore
@@ -108,4 +108,3 @@ test-results
 
 cypress/screenshots
 cypress/videos
-.npmrc

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
This prevents malicious postinstall scripts from running during `npm install`, both in CI and locally.

### Changes

- Added `.npmrc` with `ignore-scripts=true`
- Removed `.npmrc` from `.gitignore` (auth tokens belong in `~/.npmrc`, not project-level)
- Added explicit `npx cypress install` in integration workflow (Cypress needs its binary downloaded via postinstall)