### PR TITLE
chore: bump setup-node to v6 and remove invalid package-manager-cache input

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -12,10 +12,9 @@ runs:
 
   steps:
     - name: Setup Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node }}
-        package-manager-cache: false
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -18,10 +18,9 @@ runs:
       uses: actions/checkout@v4
 
     - name: Setup Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
-        package-manager-cache: false
 
     - name: Update npm
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          package-manager-cache: false
 
       - name: Install dependencies
         run: npm i --include=dev


### PR DESCRIPTION
## Summary

- Bump `actions/setup-node` from `@v3`/`@v4` to `@v6`
- Remove `package-manager-cache: false` — not a valid input, silently ignored
