### PR TITLE
ci: remove redundant build step from cross-browser workflow

### DIFF
--- a/.github/workflows/cross-browser.yml
+++ b/.github/workflows/cross-browser.yml
@@ -22,9 +22,7 @@ env:
   NODE_VERSION: 22
 
 jobs:
-
   cross-browser:
-
     name: ${{ matrix.browser }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
@@ -41,10 +39,13 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
-      - name: Build package
-        uses: ./.github/actions/build
+      - name: Setup Node
+        uses: actions/setup-node@v6
         with:
-          node: ${{ env.NODE_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install dependencies
+        run: npm i --include=dev
 
       - name: Run cross-browser tests
         uses: cypress-io/github-action@v7


### PR DESCRIPTION
## Summary

- `npm start` already wipes and rebuilds `dist/` when starting the Cypress test server, making the prior build step pointless
- Replaced the composite build action with just node setup and dependency install