### PR TITLE
chore: remove Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,0 @@
-@Library('k8sAgents') agentLibrary
-@Library('auth0') _
-SDKDeployment()


### PR DESCRIPTION
## Summary

- Removes `Jenkinsfile` from the repository
- Public repos should not reference internal build systems
- CI/CD is fully handled via GitHub Actions

## Notes

The Jenkins webhook configured at the repository or org level in GitHub settings should also be removed.