### PR TITLE
docs: fix deprecated redirectUri and syntax error in organizations example

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -470,8 +470,8 @@ ReactDOM.render(
       domain="YOUR_AUTH0_DOMAIN"
       clientId="YOUR_AUTH0_CLIENT_ID"
       authorizationParams={{
-        organization: "YOUR_ORGANIZATION_ID_OR_NAME"
-        redirectUri: window.location.origin,
+        organization: "YOUR_ORGANIZATION_ID_OR_NAME",
+        redirect_uri: window.location.origin,
       }}
     >
       <App />


### PR DESCRIPTION
## Summary

Automated documentation drift fix. 2 issues addressed in the "Use with Auth0 organizations" example (1 P1 · 1 P2).

## Changes

- `EXAMPLES.md` — replace deprecated `authorizationParams.redirectUri` with `authorizationParams.redirect_uri` (P2, runtime-deprecated in current SDK)
- `EXAMPLES.md` — add missing comma after `organization` property in same object literal (P1, syntax error in copy-pasteable example)

<details>
<summary>Full Drift Report</summary>

| # | Severity | File | Line | Issue |
|---|---|---|---|---|
| 1 | P2 | EXAMPLES.md | 474 | `authorizationParams.redirectUri` deprecated — replaced with `authorizationParams.redirect_uri` |
| 2 | P1 | EXAMPLES.md | 473 | Missing comma after `organization` property — syntax error caught during fix application |

</details>

---
🤖 Generated with [syncing-docs](https://github.com/atko-cic/claude-marketplace) skill
