### PR TITLE
feat: expose revokeRefreshToken

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -822,6 +822,14 @@ await revokeRefreshToken({ audience: 'https://api.example.com' });
 > [!IMPORTANT]
 > With [MRRT](#using-multi-resource-refresh-tokens) enabled, all audiences share the same underlying refresh token — revoking for one audience invalidates it for all of them.
 
+> [!NOTE]
+> Revoking the refresh token does not update the React auth state — `isAuthenticated` remains `true` and the current access token stays valid until it expires. The next call to `getAccessTokenSilently` will fail with `login_required`. If you want to immediately tear down the session, call `logout()` after revoking:
+>
+> ```js
+> await revokeRefreshToken();
+> await logout({ openUrl: false });
+> ```
+
 ## Connect Accounts for using Token Vault
 
 The Connect Accounts feature uses the Auth0 My Account API to allow users to link multiple third party accounts to a single Auth0 user profile.

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -11,6 +11,7 @@
 - [Protecting a route with a claims check](#protecting-a-route-with-a-claims-check)
 - [Device-bound tokens with DPoP](#device-bound-tokens-with-dpop)
 - [Using Multi Resource Refresh Tokens](#using-multi-resource-refresh-tokens)
+- [Revoke Refresh Token](#revoke-refresh-token)
 - [Connect Accounts for using Token Vault](#connect-accounts-for-using-token-vault)
 - [Access SDK Configuration](#access-sdk-configuration)
 - [Multi-Factor Authentication (MFA)](#multi-factor-authentication-mfa)
@@ -782,6 +783,44 @@ MRRT is disabled by default. To enable it, set the `useMrrt` option to `true` wh
 > [!IMPORTANT]
 > In order MRRT to work, it needs a previous configuration setting the refresh token policies.
 > Visit [configure and implement MRRT.](https://auth0.com/docs/secure/tokens/refresh-tokens/multi-resource-refresh-token/configure-and-implement-multi-resource-refresh-token)
+
+## Revoke Refresh Token
+
+Invalidate the current refresh token via the `/oauth/revoke` endpoint. Once revoked, the token can no longer be used to obtain new access tokens. This is useful when you want to force re-authentication on the next token request — for example, after a password change or detecting suspicious activity — without performing a full logout.
+
+> [!NOTE]
+> This is a no-op if `useRefreshTokens` is not enabled.
+
+```jsx
+import { useAuth0 } from '@auth0/auth0-react';
+
+const RevokeTokenButton = () => {
+  const { revokeRefreshToken } = useAuth0();
+
+  const handleRevoke = async () => {
+    try {
+      await revokeRefreshToken();
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return <button onClick={handleRevoke}>Revoke Refresh Token</button>;
+};
+
+export default RevokeTokenButton;
+```
+
+To target a specific audience, pass it as an option:
+
+```jsx
+const { revokeRefreshToken } = useAuth0();
+
+await revokeRefreshToken({ audience: 'https://api.example.com' });
+```
+
+> [!IMPORTANT]
+> With [MRRT](#using-multi-resource-refresh-tokens) enabled, all audiences share the same underlying refresh token — revoking for one audience invalidates it for all of them.
 
 ## Connect Accounts for using Token Vault
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -824,8 +824,8 @@ await revokeRefreshToken({ audience: 'https://api.example.com' });
 
 > [!NOTE]
 > Revoking the refresh token does not update the React auth state — `isAuthenticated` remains `true` and the current access token stays valid until it expires. The next call to `getAccessTokenSilently` will fail with `login_required`. If you want to immediately tear down the session, call `logout()` after revoking:
->
 > ```js
+> const { revokeRefreshToken, logout } = useAuth0();
 > await revokeRefreshToken();
 > await logout({ openUrl: false });
 > ```

--- a/__mocks__/@auth0/auth0-spa-js.tsx
+++ b/__mocks__/@auth0/auth0-spa-js.tsx
@@ -16,6 +16,7 @@ const loginWithPopup = jest.fn();
 const loginWithRedirect = jest.fn();
 const connectAccountWithRedirect = jest.fn();
 const logout = jest.fn();
+const revokeRefreshToken = jest.fn();
 const getDpopNonce = jest.fn();
 const setDpopNonce = jest.fn();
 const generateDpopProof = jest.fn();
@@ -56,6 +57,7 @@ export const Auth0Client = jest.fn(() => {
     loginWithRedirect,
     connectAccountWithRedirect,
     logout,
+    revokeRefreshToken,
     getDpopNonce,
     setDpopNonce,
     generateDpopProof,

--- a/__tests__/auth-provider.test.tsx
+++ b/__tests__/auth-provider.test.tsx
@@ -603,6 +603,53 @@ describe('Auth0Provider', () => {
     });
   });
 
+  it('should provide a revokeRefreshToken method', async () => {
+    const wrapper = createWrapper();
+    const { result } = renderHook(
+      () => useContext(Auth0Context),
+      { wrapper }
+    );
+    await waitFor(() => {
+      expect(result.current.revokeRefreshToken).toBeInstanceOf(Function);
+    });
+    await act(async () => {
+      await result.current.revokeRefreshToken({ audience: 'https://api.example.com' });
+    });
+    expect(clientMock.revokeRefreshToken).toHaveBeenCalledWith({
+      audience: 'https://api.example.com',
+    });
+  });
+
+  it('should propagate errors from revokeRefreshToken', async () => {
+    clientMock.revokeRefreshToken.mockRejectedValue(new Error('__test_error__'));
+    const wrapper = createWrapper();
+    const { result } = renderHook(
+      () => useContext(Auth0Context),
+      { wrapper }
+    );
+    await waitFor(() => {
+      expect(result.current.revokeRefreshToken).toBeInstanceOf(Function);
+    });
+    await act(async () => {
+      await expect(result.current.revokeRefreshToken()).rejects.toThrow(
+        '__test_error__'
+      );
+    });
+  });
+
+  it('should memoize the revokeRefreshToken method', async () => {
+    const wrapper = createWrapper();
+    const { result, rerender } = renderHook(
+      () => useContext(Auth0Context),
+      { wrapper }
+    );
+    await waitFor(() => {
+      const memoized = result.current.revokeRefreshToken;
+      rerender();
+      expect(result.current.revokeRefreshToken).toBe(memoized);
+    });
+  });
+
   it('should provide a getAccessTokenSilently method', async () => {
     clientMock.getTokenSilently.mockResolvedValue('token');
     const wrapper = createWrapper();

--- a/src/auth0-context.tsx
+++ b/src/auth0-context.tsx
@@ -14,6 +14,7 @@ import {
   ConnectAccountRedirectResult,
   CustomTokenExchangeOptions,
   TokenEndpointResponse,
+  type RevokeRefreshTokenOptions,
   type MfaApiClient,
   type PasskeyApiClient,
   type MyAccountApiClient
@@ -274,6 +275,23 @@ export interface Auth0ContextInterface<TUser extends User = User>
   logout: (options?: LogoutOptions) => Promise<void>;
 
   /**
+   * ```js
+   * await revokeRefreshToken();
+   * // or for a specific audience:
+   * await revokeRefreshToken({ audience: 'https://api.example.com' });
+   * ```
+   *
+   * Revokes the refresh token for the current session by calling the
+   * `/oauth/revoke` endpoint. Once revoked, the token can no longer be
+   * used to obtain new access tokens.
+   *
+   * If `useRefreshTokens` is not enabled this is a no-op.
+   * When multiple audiences share the same refresh token, revoking for
+   * one audience invalidates it for all of them.
+   */
+  revokeRefreshToken: (options?: RevokeRefreshTokenOptions) => Promise<void>;
+
+  /**
    * After the browser redirects back to the callback page,
    * call `handleRedirectCallback` to handle success and error
    * responses from Auth0. If the response is successful, results
@@ -470,6 +488,7 @@ export const initialContext = {
   loginWithPopup: stub,
   connectAccountWithRedirect: stub,
   logout: stub,
+  revokeRefreshToken: stub,
   handleRedirectCallback: stub,
   getDpopNonce: stub,
   setDpopNonce: stub,

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -20,6 +20,7 @@ import {
   ResponseType,
   CustomTokenExchangeOptions,
   TokenEndpointResponse,
+  type RevokeRefreshTokenOptions,
   type PasskeyApiClient,
   type PasskeySignupOptions,
   type PasskeyLoginOptions
@@ -259,6 +260,12 @@ const Auth0Provider = <TUser extends User = User>(opts: Auth0ProviderOptions<TUs
     [client]
   );
 
+  const revokeRefreshToken = useCallback(
+    (opts?: RevokeRefreshTokenOptions): Promise<void> =>
+      client.revokeRefreshToken(opts),
+    [client]
+  );
+
   const getAccessTokenSilently = useCallback(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async (opts?: GetTokenSilentlyOptions): Promise<any> => {
@@ -449,6 +456,7 @@ const Auth0Provider = <TUser extends User = User>(opts: Auth0ProviderOptions<TUs
       loginWithPopup,
       connectAccountWithRedirect,
       logout,
+      revokeRefreshToken,
       handleRedirectCallback,
       getDpopNonce,
       setDpopNonce,
@@ -471,6 +479,7 @@ const Auth0Provider = <TUser extends User = User>(opts: Auth0ProviderOptions<TUs
     loginWithPopup,
     connectAccountWithRedirect,
     logout,
+    revokeRefreshToken,
     handleRedirectCallback,
     getDpopNonce,
     setDpopNonce,

--- a/src/auth0-provider.tsx
+++ b/src/auth0-provider.tsx
@@ -261,8 +261,8 @@ const Auth0Provider = <TUser extends User = User>(opts: Auth0ProviderOptions<TUs
   );
 
   const revokeRefreshToken = useCallback(
-    (opts?: RevokeRefreshTokenOptions): Promise<void> =>
-      client.revokeRefreshToken(opts),
+    (options?: RevokeRefreshTokenOptions): Promise<void> =>
+      client.revokeRefreshToken(options),
     [client]
   );
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -47,7 +47,6 @@ export {
   ResponseType,
   ConnectError,
   CustomTokenExchangeOptions,
-  RevokeRefreshTokenOptions,
   TokenEndpointResponse,
   ActClaim,
   ClientConfiguration,
@@ -67,6 +66,7 @@ export {
   MyAccountApiError,
 } from '@auth0/auth0-spa-js';
 export type {
+  RevokeRefreshTokenOptions,
   FetcherConfig,
   InteractiveErrorHandler,
   // MFA Types

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -47,6 +47,7 @@ export {
   ResponseType,
   ConnectError,
   CustomTokenExchangeOptions,
+  RevokeRefreshTokenOptions,
   TokenEndpointResponse,
   ActClaim,
   ClientConfiguration,


### PR DESCRIPTION
## Summary

Closes #1134

- Expose `revokeRefreshToken` on `Auth0ContextInterface` and wire it through `Auth0Provider`
- Re-export `RevokeRefreshTokenOptions` from `@auth0/auth0-spa-js` via `src/index.tsx`
- Add tests (call, error propagation, memoization)
- Document usage in `EXAMPLES.md`

## Test plan

- [x] `npm test` passes with 100% coverage

## Manual testing

- **Basic revoke:** log in with `useRefreshTokens={true}` → call `revokeRefreshToken()` → confirm the next `getAccessTokenSilently()` fails with `login_required` (refresh token is no longer valid)
- **With audience:** log in with multiple audiences → call `revokeRefreshToken({ audience: 'https://api.example.com' })` → confirm only that audience's token is invalidated
- **No-op without refresh tokens:** configure with `useRefreshTokens={false}` → call `revokeRefreshToken()` → confirm no error is thrown and auth state is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `revokeRefreshToken` to the authentication context, with optional `audience` targeting.
  * Exposed `RevokeRefreshTokenOptions` for use with revocation calls.
* **Documentation**
  * Added a “Revoke Refresh Token” guide with React examples, including behavior when refresh tokens are disabled, multi-audience impact, and expected follow-up authentication behavior (plus optional logout snippet).
* **Tests**
  * Added tests covering method availability, audience option forwarding, error propagation, and memoization stability across rerenders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->