### PR TITLE
fix: replace ignore_branches with base_branches in coderabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,7 @@
 reviews:
   auto_review:
-    ignore_branches:
-      - 'release/**'
+    base_branches:
+      - '^(?!release/).*'
   path_filters:
     - '!dist/**'
     - '!CHANGELOG.md'


### PR DESCRIPTION
`ignore_branches` is not a valid field in the CodeRabbit schema. Replacing it with the correct `base_branches` field using a negative lookahead regex to exclude `release/**` branches from auto-review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated review configuration to apply across non-release branches.
  * Release branch reviews remain excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->