### PR TITLE
fix: group codeql-action dependabot updates and align versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action*"
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:


### PR DESCRIPTION
## Summary
- Groups all `github/codeql-action/*` Dependabot updates so init, autobuild, and analyze are always bumped together in a single PR
- Aligns any mismatched codeql-action versions in the CodeQL workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Grouped CodeQL Action updates together in automated dependency update configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->