### PR TITLE
fix: prevent open redirect via protocol-relative returnTo

### DIFF
--- a/__tests__/with-authentication-required.test.tsx
+++ b/__tests__/with-authentication-required.test.tsx
@@ -182,6 +182,33 @@ describe('withAuthenticationRequired', () => {
     );
   });
 
+  it('should sanitize protocol-relative returnTo paths to prevent open redirect', async () => {
+    // Simulate a URL like https://app.example.com//evil.com whose pathname is //evil.com.
+    // Routers (react-router, next.js, gatsby) treat //evil.com as a protocol-relative URL
+    // and redirect the user to http://evil.com.
+    window.history.replaceState({}, '', 'https://www.example.com//evil.com');
+
+    mockClient.getUser.mockResolvedValue(undefined);
+    const MyComponent = () => <>Private</>;
+    const WrappedComponent = withAuthenticationRequired(MyComponent);
+    render(
+      <Auth0Provider clientId="__test_client_id__" domain="__test_domain__">
+        <WrappedComponent />
+      </Auth0Provider>
+    );
+    await waitFor(() =>
+      expect(mockClient.loginWithRedirect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appState: expect.objectContaining({
+            returnTo: '/evil.com',
+          }),
+        })
+      )
+    );
+
+    window.history.replaceState({}, '', 'https://www.example.com/');
+  });
+
   it('should call loginWithRedirect only once even if parent state changes', async () => {
     mockClient.getUser.mockResolvedValue(undefined);
     const MyComponent = () => <>Private</>;

--- a/__tests__/with-authentication-required.test.tsx
+++ b/__tests__/with-authentication-required.test.tsx
@@ -186,27 +186,30 @@ describe('withAuthenticationRequired', () => {
     // Simulate a URL like https://app.example.com//evil.com whose pathname is //evil.com.
     // Routers (react-router, next.js, gatsby) treat //evil.com as a protocol-relative URL
     // and redirect the user to http://evil.com.
+    const originalUrl = window.location.href;
     window.history.replaceState({}, '', 'https://www.example.com//evil.com');
 
-    mockClient.getUser.mockResolvedValue(undefined);
-    const MyComponent = () => <>Private</>;
-    const WrappedComponent = withAuthenticationRequired(MyComponent);
-    render(
-      <Auth0Provider clientId="__test_client_id__" domain="__test_domain__">
-        <WrappedComponent />
-      </Auth0Provider>
-    );
-    await waitFor(() =>
-      expect(mockClient.loginWithRedirect).toHaveBeenCalledWith(
-        expect.objectContaining({
-          appState: expect.objectContaining({
-            returnTo: '/evil.com',
-          }),
-        })
-      )
-    );
-
-    window.history.replaceState({}, '', 'https://www.example.com/');
+    try {
+      mockClient.getUser.mockResolvedValue(undefined);
+      const MyComponent = () => <>Private</>;
+      const WrappedComponent = withAuthenticationRequired(MyComponent);
+      render(
+        <Auth0Provider clientId="__test_client_id__" domain="__test_domain__">
+          <WrappedComponent />
+        </Auth0Provider>
+      );
+      await waitFor(() =>
+        expect(mockClient.loginWithRedirect).toHaveBeenCalledWith(
+          expect.objectContaining({
+            appState: expect.objectContaining({
+              returnTo: '/evil.com',
+            }),
+          })
+        )
+      );
+    } finally {
+      window.history.replaceState({}, '', originalUrl);
+    }
   });
 
   it('should call loginWithRedirect only once even if parent state changes', async () => {

--- a/src/with-authentication-required.tsx
+++ b/src/with-authentication-required.tsx
@@ -18,8 +18,14 @@ const defaultOnBeforeAuthentication = async (): Promise<void> => {/* noop */ };
 /**
  * @ignore
  */
-const defaultReturnTo = (): string =>
-  `${window.location.pathname}${window.location.search}`;
+const defaultReturnTo = (): string => {
+  // Normalize the pathname to prevent protocol-relative open redirects.
+  // A URL like https://app.example.com//evil.com produces a pathname of
+  // //evil.com, which routers (react-router, next.js, gatsby) interpret as a
+  // protocol-relative URL and redirect the user to an external host.
+  const pathname = window.location.pathname.replace(/^\/\/+/, '/');
+  return `${pathname}${window.location.search}`;
+};
 
 /**
  * Options for the withAuthenticationRequired Higher Order Component


### PR DESCRIPTION
## Summary

- `defaultReturnTo` in `withAuthenticationRequired` captured `window.location.pathname` verbatim, which equals `//evil.com` when a user visits `https://app.example.com//evil.com`
- Routers (react-router, next.js, gatsby) interpret a `//`-prefixed string as a protocol-relative URL, redirecting the user to an external host
- Fix normalizes the pathname to strip leading double slashes before storing it in `appState.returnTo`

## Test plan

- [x] New regression test: simulates a double-slash pathname and asserts `loginWithRedirect` receives a sanitized single-slash `returnTo`
- [x] All existing tests pass
- [x] 100% code coverage maintained

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Sanitized protocol-relative paths in authentication redirects to prevent unsafe redirect targets.
- Preserved valid paths and query strings when setting the post-authentication return location.

## Tests

- Added coverage for paths beginning with double slashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->