### PR TITLE
chore: group @typescript-eslint deps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,6 @@ updates:
         patterns:
           - "react"
           - "react-dom"
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"


### PR DESCRIPTION
Group `@typescript-eslint/parser` and `@typescript-eslint/eslint-plugin` into a single Dependabot PR since they are always versioned together.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated grouping for `@typescript-eslint` npm dependency updates to simplify maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->