### PR TITLE
fix: update import style in useAuth0Suspense for compatibility with React older version

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -63,8 +63,23 @@ jobs:
       - name: Build SDK
         run: npm run build
 
+      - name: Pack SDK
+        run: npm pack
+
       - name: Install examples
         run: npm run install:examples
+
+      - name: Install local SDK into CRA example
+        run: npm install --prefix=examples/cra-react-router $(ls auth0-auth0-react-*.tgz)
+
+      - name: Build CRA example (production)
+        run: npm run build --prefix=examples/cra-react-router
+
+      - name: Build Next.js example (production)
+        run: npm run build --prefix=examples/nextjs-app
+
+      - name: Build Gatsby example (production)
+        run: npm run build --prefix=examples/gatsby-app
 
       - name: Run integration test (CRA)
         run: npm run test:cra

--- a/src/use-auth0-suspense.tsx
+++ b/src/use-auth0-suspense.tsx
@@ -1,7 +1,9 @@
-// Namespace import: `use` only exists as a named export from React 19, so
-// `import { use }` fails at link time for React 16-18 consumers even if they
-// never call this hook. Property access stays late-bound.
-import * as React from 'react';
+// Default import, NOT `import * as React`: webpack checks namespace member names
+// against the module's export list, so `React.use` on a namespace binding warns
+// for React 16-18 consumers even if they never call this hook (#1205). A default
+// import is react's module.exports object, so the read is unchecked. Named
+// (`import { use }`) is worse still: it fails at link time.
+import React, { useContext, useMemo } from 'react';
 import { User } from '@auth0/auth0-spa-js';
 import Auth0Context, { Auth0ContextInterface } from './auth0-context';
 
@@ -47,7 +49,7 @@ const useAuth0Suspense = <TUser extends User = User>(
     );
   }
 
-  const ctx = React.useContext(context) as Auth0ContextInterface<TUser>;
+  const ctx = useContext(context) as Auth0ContextInterface<TUser>;
 
   if (!ctx._initPromise) {
     throw new Error(
@@ -61,7 +63,7 @@ const useAuth0Suspense = <TUser extends User = User>(
   // Memoized so the returned object is referentially stable across renders,
   // matching useAuth0, which hands back the provider's memoized context.
   // Without this, `useEffect(..., [auth])` in a consumer re-runs every render.
-  return React.useMemo(() => {
+  return useMemo(() => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { isLoading, _initPromise, ...rest } = ctx;
     return rest;


### PR DESCRIPTION
## Summary

Fixes #1205. Restores React 16–18 compatibility for webpack-based consumers after 2.24.0 introduced a build-time error for React 19's `use` export.

## Root Cause

`useAuth0Suspense` accessed `React.use` through a namespace import. Webpack statically validates namespace members and fails because `use` is not exported by React 16–18, even when the hook is unused or runtime-guarded.

## Fix

Switch the React namespace import to a default import and use named imports for `useContext` and `useMemo`. This prevents webpack from statically resolving `React.use` while preserving existing React 19 behavior.

No public API, runtime behavior, or peer dependency changes.


## Testing

Verified with the repo's CRA 5 / React 18.3.1 example:

- `@auth0/auth0-react@2.24.0` → build fails with `Attempted import error: 'use' is not exported from 'react'`
- Local package with this fix → build succeeds
- Updated CI to install the SDK as a packed tarball into the CRA example and run a production build, so issues like this get caught.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated internal React hook usage without changing authentication behavior or the public API.
* **Tests**
  * Expanded integration validation by packaging and testing the SDK with CRA, Next.js, and Gatsby examples to ensure consistent behavior across supported frameworks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->