### PR TITLE
chore: add CLAUDE.md + AGENTS.md + references/ for AI agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# AI Agent Guidelines for auth0-react
+
+@./CLAUDE.md for all coding guidelines, commands, project structure, code style, testing conventions, and boundaries.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ You are a TypeScript SDK engineer working on auth0-react, the Auth0 React SPA SD
 
 ## Project Structure
 
-```
+```text
 auth0-react/
 ├── src/                               # SDK source (TypeScript)
 │   ├── index.tsx                      # Public API exports — the contract

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,128 @@
+# AI Agent Guidelines for auth0-react
+
+This document provides context and guidelines for AI coding assistants working with the auth0-react codebase.
+
+## Your Role
+
+You are a TypeScript SDK engineer working on auth0-react, the Auth0 React SPA SDK. You write small, well-tested, tree-shakeable React hooks and components that wrap `@auth0/auth0-spa-js`.
+
+---
+
+## Project Structure
+
+```
+auth0-react/
+├── src/                               # SDK source (TypeScript)
+│   ├── index.tsx                      # Public API exports — the contract
+│   ├── auth0-provider.tsx             # Auth0Provider component + telemetry wiring
+│   ├── auth0-context.tsx              # React context + Auth0ContextInterface type
+│   ├── use-auth0.tsx                  # useAuth0 hook
+│   ├── use-auth0-suspense.tsx         # useAuth0Suspense hook (React.use()-based)
+│   ├── with-auth0.tsx                 # withAuth0 HOC
+│   ├── with-authentication-required.tsx # Route protection HOC
+│   ├── auth-state.tsx                 # AuthState type
+│   ├── reducer.tsx                    # Auth state reducer
+│   ├── errors.tsx                     # OAuthError
+│   └── utils.tsx                      # Shared utilities
+├── __tests__/                         # Jest unit tests (*.test.tsx)
+├── __mocks__/@auth0/                  # Manual mock for @auth0/auth0-spa-js
+├── examples/                          # Runnable sample apps
+│   ├── cra-react-router/              # Create React App + React Router
+│   ├── gatsby-app/                    # Gatsby example
+│   ├── nextjs-app/                    # Next.js example
+│   └── users-api/                     # Express API used by examples
+├── cypress/                           # E2E smoke tests
+├── docs/                              # TypeDoc-generated API output (do not edit manually)
+├── .github/                           # CI workflows and reusable actions
+├── .version                           # Version source of truth (keep in sync with package.json)
+├── jest.config.js
+├── rollup.config.mjs
+└── package.json
+```
+
+---
+
+## Boundaries
+
+### ✅ Always Do
+
+- Run `npm test` before committing — 100% coverage threshold is enforced in CI
+- Make surgical changes — touch only what the request requires; do not refactor or reformat adjacent code
+- Use `useCallback`/`useMemo` for all values exposed on the context object (matches existing pattern in `auth0-provider.tsx`)
+- Add unit tests for all new code in `src/` (except `index.tsx`, which is excluded from coverage)
+- When adding a **new outbound request path to Auth0**, route it through the existing `client` instance (`Auth0Client` created in `Auth0Provider`) — it carries `auth0Client: { name: 'auth0-react', version }` (see `src/auth0-provider.tsx`) which causes `@auth0/auth0-spa-js` to include the `Auth0-Client` identification header on every request; never create a separate `Auth0Client` or raw HTTP client for a new auth flow
+- Keep `.version` and `package.json` `"version"` in sync — `.version` is the version source of truth used during builds
+- Update `README.md` and `EXAMPLES.md` in the same PR when changing the public API, configuration options, or supported integration patterns; update affected `examples/` sample apps too
+
+### ⚠️ Ask First
+
+- **Any breaking change — always ask first.** Never make a breaking change on your own initiative; stop and ask the maintainer before writing it.
+- Adding new dependencies
+- Modifying public API signatures (anything exported from `src/index.tsx`)
+- Changes to CI/CD configuration
+- Modifying security-related code (token handling, DPoP, `onRedirectCallback`)
+- Running integration tests (`npm run test:integration`) — Cypress against a live Auth0 tenant; slow and requires real credentials
+
+### 🚫 Never Do
+
+- Commit secrets, API keys, or tokens
+- Edit files under `dist/` or `docs/` by hand — both are build outputs
+- Remove or skip failing tests without fixing them
+- Edit `node_modules/` or lock files by hand
+- Break backward compatibility without asking first and getting explicit approval
+- Log, expose, or store tokens in cleartext
+
+---
+
+## Security Considerations
+
+- **PKCE** is handled transparently by `@auth0/auth0-spa-js`; do not bypass or replicate it.
+- **Token storage:** `InMemoryCache` (default) or `LocalStorageCache` — never write raw tokens to `localStorage` directly; always go through the cache abstraction.
+- **`onRedirectCallback`** receives `appState` after the Auth0 redirect; validate the `returnTo` URL before redirecting to prevent open-redirect attacks — reject non-relative URLs or URLs outside expected origins.
+- **DPoP** is supported; never strip or bypass the DPoP nonce mechanism — `getDpopNonce`/`setDpopNonce`/`generateDpopProof` on the context are its public surface.
+- Never `console.log` or send telemetry that includes `access_token`, `id_token`, or `refresh_token` values.
+- Secret scanning is active (`.semgrepignore`, CodeQL, Snyk, RL-secure workflows) — all commits are scanned.
+
+---
+
+> The sections below are **reference** — read each linked file only when the task requires it.
+
+## Commands
+
+See [references/commands.md](references/commands.md) for the full command list. Read when you need to build, test, lint, or format.
+
+---
+
+## Testing
+
+**Framework:** Jest 29 + @testing-library/react. Tests live in `__tests__/` (`*.test.tsx`). The `__mocks__/@auth0/auth0-spa-js.tsx` manual mock is used for all unit tests — no live tenant required.
+
+See [references/testing.md](references/testing.md) for conventions, mocking patterns, and the Cypress integration tier. Read when writing or debugging tests.
+
+---
+
+## Code Style
+
+**CI-enforced:** single quotes and 80-char line width (Prettier); TypeScript `strict`, `noUnusedLocals`, `noUnusedParameters`, `noImplicitReturns`; React Hooks exhaustive-deps (ESLint).
+
+See [references/code-style.md](references/code-style.md) for naming conventions, good/bad examples, and project patterns. Read when writing new source.
+
+---
+
+## Git Workflow
+
+See [references/git-workflow.md](references/git-workflow.md) for branch naming, commit message format, and PR process. Read before opening a PR.
+
+---
+
+## Common Pitfalls
+
+See [references/pitfalls.md](references/pitfalls.md) for auth0-react-specific gotchas. Read when troubleshooting unexpected behaviour.
+
+---
+
+## Docs Update Rules
+
+> A PR that adds or changes public API, configuration, or integration patterns is **not complete** until the relevant docs are updated in the same PR.
+
+See [references/docs-update.md](references/docs-update.md) for the tracked-docs inventory and code-to-docs mapping. Read when changing public API or integration patterns.

--- a/references/code-style.md
+++ b/references/code-style.md
@@ -1,0 +1,54 @@
+# Code Style Reference — auth0-react
+
+## Naming Conventions
+
+| Construct | Convention | Example |
+|-----------|-----------|---------|
+| React components | PascalCase | `Auth0Provider`, `WithAuthenticationRequired` |
+| Hooks | camelCase with `use` prefix | `useAuth0`, `useAuth0Suspense` |
+| HOCs | camelCase with `with` prefix | `withAuth0`, `withAuthenticationRequired` |
+| TypeScript types / interfaces | PascalCase | `Auth0ContextInterface`, `AppState`, `AuthState` |
+| Internal helpers | camelCase | `loginError`, `tokenError`, `hasAuthParams` |
+| Reducer action types | string literal in UPPER_SNAKE_CASE | `'INITIALISED'`, `'LOGIN_POPUP_STARTED'`, `'ERROR'` |
+
+## CI-Enforced Rules
+
+These rules fail CI if violated — treat them as guardrails, not suggestions:
+
+- **Single quotes** for all strings (Prettier; `.prettierrc`: `"singleQuote": true`)
+- **80-char max line width** (Prettier; `.prettierrc`: `"printWidth": 80`)
+- **TypeScript `strict`** mode — all strict checks active (`tsconfig.json`)
+- **`noUnusedLocals` + `noUnusedParameters`** — every declared variable and parameter must be used
+- **`noImplicitReturns`** — all code paths in a function must return a value (or be `void`)
+- **React Hooks exhaustive-deps** (`eslint-plugin-react-hooks/recommended`) — all reactive values must appear in the dependency array of `useEffect` / `useCallback` / `useMemo`
+
+## Dominant Patterns
+
+### Context methods are always memoized
+
+All methods exposed on the context value are wrapped in `useCallback`; the context object itself is built with `useMemo`. This prevents unnecessary re-renders when the provider re-renders:
+
+**✅ Good — memoized with `useCallback`:**
+```ts
+const getIdTokenClaims = useCallback(
+  () => client.getIdTokenClaims(),
+  [client]
+);
+```
+
+**❌ Bad — creates a new function reference on every render:**
+```ts
+const getIdTokenClaims = () => client.getIdTokenClaims();
+```
+
+### Auth state uses `useReducer`
+
+Auth state (`isAuthenticated`, `isLoading`, `user`, `error`) is managed by a single `useReducer` in `Auth0Provider`. Dispatch typed actions (`{ type: 'INITIALISED', user }`) instead of calling `setState` individually — keeps state transitions predictable and testable.
+
+### Errors are normalised before dispatch or rethrow
+
+Wrap unknown errors with `loginError(error)` or `tokenError(error)` before dispatching or rethrowing. Do not let raw `unknown` error objects escape into the context or test assertions.
+
+### `'use client'` directive
+
+The Rollup build injects `'use client'` into both CJS and ESM bundle outputs. Do not add `'use client'` to individual source files — it is a build-time concern. The `test:dist:only` CI job asserts its presence in the built artifact.

--- a/references/commands.md
+++ b/references/commands.md
@@ -1,0 +1,84 @@
+# Commands Reference — auth0-react
+
+## Build
+
+```bash
+npm run build
+# Runs ESLint then Rollup (rollup.config.mjs); outputs CJS + ESM bundles to dist/
+```
+
+## Test (unit — safe, no credentials)
+
+```bash
+npm test
+# jest --coverage; enforces 100% branches/functions/lines/statements
+```
+
+## Test (single file)
+
+```bash
+npx jest __tests__/auth-provider.test.tsx
+```
+
+## Test (watch mode)
+
+```bash
+npx jest --watch
+```
+
+## Test (dist 'use client' sanity check)
+
+```bash
+npm run test:dist:only
+# Asserts the 'use client' directive is present in built bundles.
+# Requires a prior build; CI runs this automatically after build.
+```
+
+## Lint
+
+```bash
+npm run lint
+# eslint --ext=tsx ./src ./__tests__
+```
+
+## Format (staged — run by Husky pre-commit)
+
+```bash
+npx pretty-quick --staged
+# To format all files: npx prettier --write .
+```
+
+## Type check
+
+```bash
+npx tsc --noEmit
+# Strict mode; noUnusedLocals, noUnusedParameters, noImplicitReturns enforced
+```
+
+## Clean
+
+```bash
+rm -rf dist/
+```
+
+## Generate API docs
+
+```bash
+npm run docs
+# TypeDoc → docs/ (do not edit the generated output manually)
+```
+
+## Dev server
+
+```bash
+npm start
+# rollup -cw; serves a demo at http://localhost:3000 with live reload
+```
+
+## Integration tests (⚠️ Ask First — requires live Auth0 tenant)
+
+```bash
+# Requires: CYPRESS_USER_EMAIL, CYPRESS_USER_PASSWORD, TEST_DOMAIN, TEST_CLIENT_ID, TEST_AUDIENCE
+CYPRESS_USER_EMAIL=<email> CYPRESS_USER_PASSWORD=<pw> npm run test:integration
+# Runs Cypress smoke tests against CRA, Next.js, and Gatsby example apps
+```

--- a/references/docs-update.md
+++ b/references/docs-update.md
@@ -1,0 +1,25 @@
+# Docs Update Rules — auth0-react
+
+## Tracked Docs
+
+| Doc | What it covers | Exists |
+|-----|---------------|--------|
+| `README.md` | Installation (npm/yarn), Auth0 dashboard setup, SDK configuration (`Auth0Provider` props), API reference table, feedback and contributing links | Present |
+| `EXAMPLES.md` | Runnable code samples: class components, route protection, API calls with access tokens, custom token exchange, DPoP, MRRT, revoke refresh token, online access, account linking, organizations, Next.js App Router (Server Components), react-router v6, Gatsby, Next.js SPA mode | Present |
+| `examples/` | Runnable sample apps: `cra-react-router/`, `gatsby-app/`, `nextjs-app/`, `users-api/` (Express API) | Present |
+
+## When You Change Code, Update These Docs
+
+This is a **library / SDK** — the public surface is the symbols exported from `src/index.tsx`.
+
+| When this changes | Update these docs |
+|-------------------|-------------------|
+| Public API exports (`src/index.tsx`) | `README.md` (API reference section), `EXAMPLES.md` (all affected samples), affected `examples/` apps |
+| Configuration options (`Auth0ProviderOptions`, `Auth0ClientOptions` fields) | `README.md` (Configure the SDK section) |
+| Authentication flow (redirect, popup, silent auth, custom token exchange) | `README.md` (Getting Started / Configure the SDK), `EXAMPLES.md` (affected auth examples) |
+| Install / package name / peer dependency requirements | `README.md` (Installation section) |
+| New public method or exported function added | `EXAMPLES.md` (add a usage sample showing the new method) |
+| Public method or exported function removed or renamed | `README.md` (remove/update references), `EXAMPLES.md` (remove/update affected samples), affected `examples/` apps |
+| New integration pattern supported (new framework, new auth flow) | `EXAMPLES.md` (add an integration example section) |
+
+> When you touch code that maps to a doc above, update that doc **in the same PR** — do not defer.

--- a/references/git-workflow.md
+++ b/references/git-workflow.md
@@ -13,7 +13,7 @@
 
 This repo uses Conventional Commits style. PR titles are linted by the `lint-pr-title` CI workflow.
 
-```
+```text
 <type>(<scope>): <subject>
 
 feat(provider): add DPoP nonce refresh support

--- a/references/git-workflow.md
+++ b/references/git-workflow.md
@@ -1,0 +1,38 @@
+# Git Workflow Reference — auth0-react
+
+## Branch Naming
+
+| Purpose | Pattern | Example |
+|---------|---------|---------|
+| Feature | `feat/<short-description>` | `feat/dpop-revocation` |
+| Bug fix | `fix/<short-description>` | `fix/open-redirect-callback` |
+| Chore / maintenance | `chore/<short-description>` | `chore/update-auth0-spa-js` |
+| Release | `release/v<major>` | `release/v3` (major-version work only) |
+
+## Commit Messages
+
+This repo uses Conventional Commits style. PR titles are linted by the `lint-pr-title` CI workflow.
+
+```
+<type>(<scope>): <subject>
+
+feat(provider): add DPoP nonce refresh support
+fix(withAuthRequired): sanitize returnTo URL before redirect
+chore(deps): bump @auth0/auth0-spa-js to 2.25.0
+test(hooks): add coverage for useAuth0Suspense retry path
+```
+
+Common types: `feat`, `fix`, `chore`, `docs`, `test`, `refactor`, `ci`
+
+## Pull Requests
+
+The **Auth0 org-level PR template** applies — [github.com/auth0/.github/blob/master/.github/PULL_REQUEST_TEMPLATE.md](https://github.com/auth0/.github/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
+
+Sections to fill out: **Description** (what and why), **References** (linked issue or ticket), **Testing** (how the change was tested), **Checklist** — key items:
+- Adds test coverage for new/changed functionality
+- Added documentation for new/changed functionality
+- Targets the correct base branch (use `release/v<major>` for breaking changes, `main` otherwise)
+
+## Husky Pre-commit Hook
+
+`npx pretty-quick --staged` runs automatically on every commit, formatting only the staged files. If Prettier reformats a file you did not intend to touch, use `git add -p` to stage selectively.

--- a/references/pitfalls.md
+++ b/references/pitfalls.md
@@ -19,7 +19,20 @@ Do not swallow the error or wrap the entire component in a generic error boundar
 
 ## 4. URL not cleaned up after redirect
 
-If you do not supply `onRedirectCallback`, the default uses `window.history.replaceState` to strip `?code=&state=` from the URL. With a client-side router (React Router, Next.js router), supply a custom callback that calls `router.replace(appState?.returnTo ?? '/')` — otherwise the router's internal location state stays stale and back-button navigation breaks.
+If you do not supply `onRedirectCallback`, the default uses `window.history.replaceState` to strip `?code=&state=` from the URL. With a client-side router (React Router, Next.js router), supply a custom callback — validate `returnTo` before navigating to prevent open-redirect attacks, then fall back to `/`:
+
+```ts
+onRedirectCallback={(appState) => {
+  const returnTo = appState?.returnTo;
+  const safeReturnTo =
+    returnTo?.startsWith('/') && !returnTo.startsWith('//')
+      ? returnTo
+      : '/';
+  router.replace(safeReturnTo);
+}}
+```
+
+Without a custom callback the router's internal location state stays stale and back-button navigation breaks.
 
 ## 5. Multiple `Auth0Provider` instances sharing state
 

--- a/references/pitfalls.md
+++ b/references/pitfalls.md
@@ -1,0 +1,29 @@
+# Common Pitfalls — auth0-react
+
+## 1. Hook called outside `Auth0Provider`
+
+`useAuth0` and `useAuth0Suspense` read from React context. If no `Auth0Provider` ancestor is present, the context is the uninitialized `initialContext` — every method is a no-op and `isAuthenticated` is always `false`. Wrap the component tree in `<Auth0Provider>` at the application root.
+
+## 2. `'use client'` in Next.js App Router
+
+The SDK bundles `'use client'` into its output files so `Auth0Provider` can be imported directly from a Server Component (e.g. `app/layout.tsx`). However, **any component that calls `useAuth0` must itself be a Client Component** — add `'use client'` to the top of those files. Forgetting this causes a "hooks can only be called inside a Client Component" build error.
+
+## 3. `getAccessTokenSilently` throwing unexpectedly
+
+The method throws typed errors from `@auth0/auth0-spa-js` on failure. Handle these at the call site:
+- `MissingRefreshTokenError` — refresh token rotation expired; redirect to login
+- `MissingScopesError` — requested scope not granted on the current token
+- `TimeoutError` — silent auth iframe timed out (e.g. 3rd-party cookie blocked)
+
+Do not swallow the error or wrap the entire component in a generic error boundary — distinct error types need distinct recovery paths.
+
+## 4. URL not cleaned up after redirect
+
+If you do not supply `onRedirectCallback`, the default uses `window.history.replaceState` to strip `?code=&state=` from the URL. With a client-side router (React Router, Next.js router), supply a custom callback that calls `router.replace(appState?.returnTo ?? '/')` — otherwise the router's internal location state stays stale and back-button navigation breaks.
+
+## 5. Multiple `Auth0Provider` instances sharing state
+
+When nesting two providers (e.g. for account linking), you must:
+- Pass a distinct `context` prop (`React.createContext(initialContext)`) to each provider and pass the same context to the matching `useAuth0` / `withAuth0` / `withAuthenticationRequired` calls
+- Set `skipRedirectCallback` on each provider for the other provider's `redirect_uri` to avoid one provider consuming the other's callback code
+- Use distinct `audience` + `scope` combinations if both use `localStorage`, so the cache key differs and one provider does not overwrite the other's cached session

--- a/references/testing.md
+++ b/references/testing.md
@@ -1,0 +1,70 @@
+# Testing Reference — auth0-react
+
+## Framework & Location
+
+| Item | Value |
+|------|-------|
+| Framework | Jest 29 + @testing-library/react 16 |
+| Test directory | `__tests__/` |
+| File pattern | `__tests__/*.test.tsx` |
+| Mock directory | `__mocks__/@auth0/auth0-spa-js.tsx` |
+| Test environment | jsdom (jest-environment-jsdom) |
+| Coverage threshold | 100% branches / functions / lines / statements |
+| Coverage exclusions | `/__tests__/`, `index.tsx` |
+
+## Running Unit Tests (no credentials required)
+
+```bash
+# All tests with coverage
+npm test
+
+# Single file
+npx jest __tests__/auth-provider.test.tsx
+
+# Watch mode
+npx jest --watch
+```
+
+The default `npm test` suite is unit-only — no Auth0 tenant or network access required. All calls to `Auth0Client` go through the manual mock.
+
+## Integration / Acceptance Tests
+
+> ⚠️ These tests start real example apps (CRA, Next.js, Gatsby) and run Cypress smoke tests against a live Auth0 tenant. They are slow and require real credentials. **Ask before running** (see Boundaries in CLAUDE.md).
+
+```bash
+# Requires:
+#   CYPRESS_USER_EMAIL    — test user email on your Auth0 tenant
+#   CYPRESS_USER_PASSWORD — test user password
+#   TEST_DOMAIN, TEST_CLIENT_ID, TEST_AUDIENCE — Auth0 app configuration
+
+CYPRESS_USER_EMAIL=<email> CYPRESS_USER_PASSWORD=<pw> npm run test:integration
+```
+
+See `examples/README.md` for example app setup instructions.
+
+## Testing Conventions
+
+- **Grouping:** `describe('ComponentName / hookName', () => { ... })`
+- **Naming:** `it('should <behaviour> when <condition>', ...)`
+- **Async hooks:** use `renderHook` + `waitFor` from `@testing-library/react`
+- **Rendered components:** use `render` + `screen` + `act` for event-driven state changes
+- **URL cleanup:** `afterEach(() => { window.history.pushState({}, document.title, '/'); })` to restore URL state between redirect-related tests
+- **Provider wrapping:** import `createWrapper()` from `__tests__/helpers.tsx` to wrap hooks in `Auth0Provider` with sensible test defaults
+
+## Mocking `@auth0/auth0-spa-js`
+
+The manual mock at `__mocks__/@auth0/auth0-spa-js.tsx` provides `jest.fn()` stubs for every `Auth0Client` method. Configure per-test behaviour with `.mockResolvedValueOnce`:
+
+```ts
+const clientMock = jest.mocked(new Auth0Client({ clientId: '', domain: '' }));
+
+// Configure for a specific test scenario
+clientMock.checkSession.mockResolvedValueOnce(undefined);
+clientMock.getUser.mockResolvedValue({ sub: 'user123', name: 'Test User' });
+```
+
+Do not replace the manual mock with inline `jest.mock()` — the shared file keeps all method stubs consistent and avoids re-declaring the full `Auth0Client` shape in every test file.
+
+## Coverage
+
+100% coverage is enforced by Jest. The `coveragePathIgnorePatterns` config excludes `/__tests__/` and `index.tsx` (the re-export barrel). All new code added to other files under `src/` must have branch, function, line, and statement coverage.

--- a/references/testing.md
+++ b/references/testing.md
@@ -56,6 +56,8 @@ See `examples/README.md` for example app setup instructions.
 The manual mock at `__mocks__/@auth0/auth0-spa-js.tsx` provides `jest.fn()` stubs for every `Auth0Client` method. Configure per-test behaviour with `.mockResolvedValueOnce`:
 
 ```ts
+import { Auth0Client } from '@auth0/auth0-spa-js';
+
 const clientMock = jest.mocked(new Auth0Client({ clientId: '', domain: '' }));
 
 // Configure for a specific test scenario


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` (128 lines) with persona, project structure, three-tier boundaries, security considerations, and lazy-loaded pointers to `references/`
- Adds `AGENTS.md` that imports `@./CLAUDE.md` as the single source of truth for all AI coding agents
- Adds six `references/*.md` files covering commands, testing conventions, code style, git workflow, SDK-specific pitfalls, and docs-update mapping

## Repo-specific detection

- **Language/ecosystem:** TypeScript, React SPA SDK wrapping `@auth0/auth0-spa-js`
- **Build:** Rollup via `npm run build` (ESLint + Rollup → CJS/ESM bundles in `dist/`); `'use client'` directive injected at build time and verified by `npm run test:dist:only`
- **Tests:** Jest 29 + @testing-library/react (unit, jsdom, 100% coverage threshold); Cypress 15 (integration against live Auth0 tenant — Ask-First)
- **Lint:** ESLint `@typescript-eslint/recommended` + `eslint-plugin-react-hooks`; Prettier pre-commit hook via Husky
- **Telemetry:** `auth0Client: { name: 'auth0-react', version }` set in `src/auth0-provider.tsx` (`toAuth0ClientOptions`) passes the `Auth0-Client` header via `@auth0/auth0-spa-js`; new API calls must route through the existing `client` instance
- **Version source:** `.version` (synced with `package.json`) — both must stay in sync
- **Docs:** `README.md` ✅ current, `EXAMPLES.md` ✅ current (covers all public API including MFA, passkeys, MyAccount, DPoP, custom token exchange, account linking)

## Validation

- All 23 paths in the structure tree resolve on disk
- All commands verified against `package.json` scripts and `.github/workflows/test.yml`
- `CLAUDE.md` is 128 lines (under 200-line target)
- No placeholder text, no stale version literals, no invented tooling
