### PR TITLE
fix: bump next to 16.3.3 in nextjs-app example

### DIFF
--- a/examples/nextjs-app/package.json
+++ b/examples/nextjs-app/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@auth0/auth0-react": "file:../..",
-    "next": "16.2.11",
+    "next": "16.3.3",
     "react": "file:../../node_modules/react",
     "react-dom": "file:../../node_modules/react-dom"
   }


### PR DESCRIPTION
## Summary
- Bumps `next` from `16.2.11` to `16.3.3` in `examples/nextjs-app` to address a critical (CVSS 9.8) vulnerability in the Next.js dependency.

## Test plan
- [x] Verify `npm audit` no longer reports the Next.js critical vulnerability in `examples/nextjs-app`
- [x] Verify `npm run build` passes in `examples/nextjs-app`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Next.js version used by the example application.
  * Includes the latest maintenance updates and improvements from the newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->