### PR TITLE
fix: override sharp to >=0.35.0 in gatsby-app

### DIFF
--- a/examples/gatsby-app/package.json
+++ b/examples/gatsby-app/package.json
@@ -33,5 +33,10 @@
   },
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "overrides": {
+    "gatsby-sharp": {
+      "sharp": ">=0.35.0"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Adds an `overrides` entry in `examples/gatsby-app/package.json` to force `sharp@>=0.35.0` scoped to `gatsby-sharp`, resolving version conflicts that can cause install/build failures.

## Test plan

- [x] `npm install` resolves `sharp@0.35.4` under `gatsby-sharp`
- [x] `gatsby build` completes successfully with no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image processing compatibility by ensuring Gatsby uses a supported version of the Sharp image library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->