### PR TITLE
chore(deps): bump react-router-dom to 7.18.0 in cra-react-router example

### DIFF
--- a/examples/cra-react-router/package.json
+++ b/examples/cra-react-router/package.json
@@ -9,7 +9,7 @@
     "@types/react-dom": "18.3.5",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-router-dom": "^6.3.0",
+    "react-router-dom": "^7.18.0",
     "react-scripts": "^5.0.1",
     "typescript": "^4.6.3"
   },


### PR DESCRIPTION
Upgrades `react-router-dom` from `^6.3.0` to `^7.18.0` in the `cra-react-router` example to fix two vulnerabilities in `react-router@6.x`:

- CVE-2026-53666 — Unsafe Reflection (MEDIUM, CVSS 6.9)
- CVE-2026-53669 — Open Redirect (HIGH, CVSS 8.2)

No SDK source or published package is affected; the vulnerability is scoped to the example app only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the React Router dependency used by the Create React App example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->